### PR TITLE
#24: Rework environment configs and plugin activation 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Closes #[ISSUE_ID]
+
+- [List what the PR does...]
+
+## To Review
+
+- [ ] Checkout Branch.
+- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
+- [ ] Go to http://the-world-wp.lndo.site/.
+
+> ...then...
+
+- [ ] [Add more review steps...]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+    "cSpell.words": [
+        "ABSPATH",
+        "DOCROOT",
+        "Lando",
+        "multidev",
+        "multidevs",
+        "SITEURL",
+        "ssot",
+        "untrailingslashit",
+        "wpcfm",
+        "WPINC"
+    ],
+    "cSpell.ignorePaths": [
+        "package-lock.json",
+        "node_modules",
+        "vscode-extension",
+        ".git/objects",
+        ".vscode",
+        ".vscode-insiders",
+        "wp-content/plugins"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Shaping the future of audio by building technology, training talented producers 
 
 - Lando (https://docs.lando.dev/) - version `>=3.6`
 - Node `^16.x`
+- PHP_CodeSniffer (https://github.com/squizlabs/PHP_CodeSniffer) - `>=3.6`
+  - WordPress-Coding-Standards (https://github.com/WordPress/WordPress-Coding-Standards) - `>=2.3`
 
 
 ## Setup

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WordPress Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<description>The Coding standard for the WordPress Coding Standards itself.</description>
+
+	<file>.</file>
+
+	<arg value="sp"/>
+	<arg name="extensions" value="php"/>
+	<arg name="basepath" value="."/>
+	<arg name="parallel" value="8"/>
+
+	<exclude-pattern>/bin/class-ruleset-test.php</exclude-pattern>
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<rule ref="WordPress">
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+	</rule>
+
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="alignMultilineItems" value="!=100"/>
+			<property name="exact" value="false" phpcs-only="true"/>
+		</properties>
+	</rule>
+
+	<rule ref="PSR2.Methods.FunctionClosingBrace"/>
+
+	<!-- Check code for cross-version PHP compatibility. -->
+	<!-- <config name="testVersion" value="5.4-"/> -->
+	<!-- <rule ref="PHPCompatibility"> -->
+		<!-- Exclude PHP constants back-filled by PHPCS. -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/> -->
+		<!-- <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/> -->
+	<!-- </rule> -->
+
+</ruleset>

--- a/wp-config-constants.php
+++ b/wp-config-constants.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ Description: Set up config constants.
+ Author: Rick Peterman
+*/
+
+/**
+ * Name of server platform. Used to load config files specific to that platform.
+ */
+define('SERVER_PLATFORM_NAME', 'pantheon');
+
+/**
+ * Name of the environment variable that acts as a flag for the platform server.
+ */
+define('SERVER_PLATFORM_ENVIRONMENT_VARIABLE_NAME', 'PANTHEON_ENVIRONMENT');

--- a/wp-config-development.php
+++ b/wp-config-development.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Development configuration.
+ * !!! IMPORTANT: NEVER include wp-settings.php !!!
+ */
+
+// Ensure debug mode is enabled.
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define('WP_DEBUG', true);
+}

--- a/wp-config-production.php
+++ b/wp-config-production.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Production configuration.
+ * !!! IMPORTANT: NEVER include wp-settings.php !!!
+ */
+
+// Ensure debug mode is disabled.
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define('WP_DEBUG', false);
+}

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,18 +1,17 @@
 <?php
-/**
- * This config file is yours to hack on. It will work out of the box on Pantheon
- * but you may find there are a lot of neat tricks to be used here.
- *
- * See our documentation for more details:
- *
- * https://pantheon.io/docs
- */
+
+require_once(dirname(__FILE__) . '/wp-config-constants.php');
 
 /**
- * Pantheon platform settings. Everything you need should already be set.
+ * Server platform settings.
+ *
+ * Loads on platform servers and Lando environments using a recipe for that platform.
+ *
+ * This config MUST translate platform environment type variable to the appropriate
+ * value for `WP_ENVIRONMENT_TYPE`, which will be used to load environment config settings.
  */
-if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-	require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
+if (file_exists(dirname(__FILE__) . '/wp-config-' . SERVER_PLATFORM_NAME . '.php') && isset($_ENV[SERVER_PLATFORM_ENVIRONMENT_VARIABLE_NAME])) {
+	require_once(dirname(__FILE__) . '/wp-config-' . SERVER_PLATFORM_NAME . '.php');
 
 /**
  * Local configuration information.
@@ -20,16 +19,24 @@ if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['P
  * If you are working in a local/desktop development environment and want to
  * keep your config separate, we recommend using a 'wp-config-local.php' file,
  * which you should also make sure you .gitignore.
+ *
+ * Not loaded when server platform config would be used, eg. Lando environment using a platform recipe.
  */
-} elseif (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])){
+} elseif (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV[SERVER_PLATFORM_ENVIRONMENT_VARIABLE_NAME])){
+	/**
+	 * Set WP_ENVIRONMENT_TYPE to development.
+	 */
+	if (getenv('WP_ENVIRONMENT_TYPE') === false) {
+		putenv('WP_ENVIRONMENT_TYPE=development');
+	}
 	# IMPORTANT: ensure your local config does not include wp-settings.php
 	require_once(dirname(__FILE__) . '/wp-config-local.php');
 
 /**
- * This block will be executed if you are NOT running on Pantheon and have NO
+ * This block will be executed if you are NOT running on platform server or Lando recipe, and have NO
  * wp-config-local.php. Insert alternate config here if necessary.
  *
- * If you are only running on Pantheon, you can ignore this block.
+ * If you are only running on a platform server or Lando recipe, you can ignore this block.
  */
 } else {
 	define('DB_NAME',          'database_name');

--- a/wp-config.php
+++ b/wp-config.php
@@ -39,20 +39,23 @@ if (file_exists(dirname(__FILE__) . '/wp-config-' . SERVER_PLATFORM_NAME . '.php
  * If you are only running on a platform server or Lando recipe, you can ignore this block.
  */
 } else {
-	define('DB_NAME',          'database_name');
-	define('DB_USER',          'database_username');
-	define('DB_PASSWORD',      'database_password');
-	define('DB_HOST',          'database_host');
-	define('DB_CHARSET',       'utf8');
-	define('DB_COLLATE',       '');
-	define('AUTH_KEY',         'put your unique phrase here');
-	define('SECURE_AUTH_KEY',  'put your unique phrase here');
-	define('LOGGED_IN_KEY',    'put your unique phrase here');
-	define('NONCE_KEY',        'put your unique phrase here');
-	define('AUTH_SALT',        'put your unique phrase here');
-	define('SECURE_AUTH_SALT', 'put your unique phrase here');
-	define('LOGGED_IN_SALT',   'put your unique phrase here');
-	define('NONCE_SALT',       'put your unique phrase here');
+  /**
+   *
+   */
+	// define('DB_NAME',          'database_name');
+	// define('DB_USER',          'database_username');
+	// define('DB_PASSWORD',      'database_password');
+	// define('DB_HOST',          'database_host');
+	// define('DB_CHARSET',       'utf8');
+	// define('DB_COLLATE',       '');
+	// define('AUTH_KEY',         'put your unique phrase here');
+	// define('SECURE_AUTH_KEY',  'put your unique phrase here');
+	// define('LOGGED_IN_KEY',    'put your unique phrase here');
+	// define('NONCE_KEY',        'put your unique phrase here');
+	// define('AUTH_SALT',        'put your unique phrase here');
+	// define('SECURE_AUTH_SALT', 'put your unique phrase here');
+	// define('LOGGED_IN_SALT',   'put your unique phrase here');
+	// define('NONCE_SALT',       'put your unique phrase here');
 }
 
 
@@ -67,17 +70,22 @@ if (file_exists(dirname(__FILE__) . '/wp-config-' . SERVER_PLATFORM_NAME . '.php
 $table_prefix = 'wp_';
 
 /**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * You may want to examine $_ENV['PANTHEON_ENVIRONMENT'] to set this to be
- * "true" in dev, but false in test and live.
- */
-if ( ! defined( 'WP_DEBUG' ) ) {
-	define('WP_DEBUG', false);
+ * Enable production environment configs.
+ * - Staging
+ * - Production
+*/
+if ( in_array( getenv('WP_ENVIRONMENT_TYPE'), array( 'staging', 'production' ) ) ){
+	# IMPORTANT: ensure production config does not include wp-settings.php
+  require_once(dirname(__FILE__) . '/wp-config-production.php');
+}
+/**
+ * Enable development environment configs.
+ * - Local
+ * - Development
+*/
+else {
+	# IMPORTANT: ensure development config does not include wp-settings.php
+  require_once(dirname(__FILE__) . '/wp-config-development.php');
 }
 
 /* That's all, stop editing! Happy Pressing. */

--- a/wp-content/config/dev/dev_active_plugins.json
+++ b/wp-content/config/dev/dev_active_plugins.json
@@ -1,4 +1,0 @@
-{
-    "active_plugins": "a:16:{i:0;s:44:\"wp-native-php-sessions\/pantheon-sessions.php\";i:1;s:41:\"acf-to-rest-api\/class-acf-to-rest-api.php\";i:2;s:30:\"advanced-custom-fields\/acf.php\";i:3;s:19:\"akismet\/akismet.php\";i:4;s:35:\"co-authors-plus\/co-authors-plus.php\";i:5;s:43:\"custom-post-type-ui\/custom-post-type-ui.php\";i:6;s:37:\"disable-comments\/disable-comments.php\";i:7;s:35:\"newspack-blocks\/newspack-blocks.php\";i:8;s:49:\"newspack-image-credits\/newspack-image-credits.php\";i:9;s:45:\"newspack-newsletters\/newspack-newsletters.php\";i:11;s:11:\"pwa\/pwa.php\";i:12;s:27:\"redirection\/redirection.php\";i:13;s:41:\"wordpress-importer\/wordpress-importer.php\";i:14;s:24:\"wordpress-seo\/wp-seo.php\";i:15;s:27:\"wp-cfm-path\/wp-cfm-path.php\";i:16;s:17:\"wp-cfm\/wp-cfm.php\";}",
-    ".label": "Dev Active Plugins"
-}

--- a/wp-content/config/live/live_active_plugins.json
+++ b/wp-content/config/live/live_active_plugins.json
@@ -1,4 +1,0 @@
-{
-    "active_plugins": "a:17:{i:0;s:41:\"acf-to-rest-api\/class-acf-to-rest-api.php\";i:1;s:30:\"advanced-custom-fields\/acf.php\";i:2;s:19:\"akismet\/akismet.php\";i:3;s:35:\"co-authors-plus\/co-authors-plus.php\";i:4;s:43:\"custom-post-type-ui\/custom-post-type-ui.php\";i:5;s:35:\"google-site-kit\/google-site-kit.php\";i:6;s:19:\"jetpack\/jetpack.php\";i:7;s:35:\"newspack-blocks\/newspack-blocks.php\";i:8;s:49:\"newspack-image-credits\/newspack-image-credits.php\";i:9;s:45:\"newspack-newsletters\/newspack-newsletters.php\";i:10;s:61:\"pantheon-advanced-page-cache\/pantheon-advanced-page-cache.php\";i:11;s:11:\"pwa\/pwa.php\";i:12;s:27:\"redirection\/redirection.php\";i:13;s:41:\"wordpress-importer\/wordpress-importer.php\";i:14;s:24:\"wordpress-seo\/wp-seo.php\";i:15;s:27:\"wp-cfm-path\/wp-cfm-path.php\";i:16;s:17:\"wp-cfm\/wp-cfm.php\";}",
-    ".label": "Live Active Plugins"
-}

--- a/wp-content/mu-plugins/load.php
+++ b/wp-content/mu-plugins/load.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Load MU Plugins organized in subdirectories.
+ */
+
+// Opens the must-use plugins directory
+$wpmu_plugin_dir = opendir(WPMU_PLUGIN_DIR);
+
+// Lists all the entries in this directory
+while (false !== ($entry = readdir($wpmu_plugin_dir))) {
+  $path = WPMU_PLUGIN_DIR . '/' . $entry;
+
+  // Is the current entry a subdirectory?
+  if ($entry != '.' && $entry != '..' && is_dir($path)) {
+  // Includes the corresponding plugin
+  require($path . '/' . $entry . '.php');
+  }
+}
+
+// Closes the directory
+closedir($wpmu_plugin_dir);

--- a/wp-content/mu-plugins/the-world-site-config/configs/development/development-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/development/development-config.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Configuration for development environments.
+ */

--- a/wp-content/mu-plugins/the-world-site-config/configs/development/development-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/development/development-plugins.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Define and activate global plugins.
+ */
+define('DEVELOPMENT_PLUGINS', array());

--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-config.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Global configuration for all environments.
+ */

--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Define global plugins.
+ */
+define('GLOBAL_PLUGINS', array(
+  'wp-native-php-sessions/pantheon-sessions.php',
+  'acf-to-rest-api/class-acf-to-rest-api.php',
+  'advanced-custom-fields/acf.php',
+  'co-authors-plus/co-authors-plus.php',
+  'custom-post-type-ui/custom-post-type-ui.php',
+  'disable-comments/disable-comments.php',
+  'newspack-blocks/newspack-blocks.php',
+  'newspack-image-credits/newspack-image-credits.php',
+  'newspack-newsletters/newspack-newsletters.php',
+  'pwa/pwa.php',
+  'redirection/redirection.php',
+  'wordpress-importer/wordpress-importer.php',
+  'wordpress-seo/wp-seo.php',
+  'wp-cfm-path/wp-cfm-path.php',
+  'wp-cfm/wp-cfm.php',
+));

--- a/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Configuration for production environments.
+ */
+
+# Disable jetpack_development_mode.
+add_filter( 'jetpack_development_mode', '__return_false' );
+
+/**
+ * STOP production configuration here.
+ */
+
+/**
+ * Load staging specific config now so it can override
+ * production settings.
+ */
+if (WP_ENVIRONMENT_TYPE === 'staging') {
+  require_once(dirname(__FILE__) . '/staging-config.php');
+}

--- a/wp-content/mu-plugins/the-world-site-config/configs/production/production-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/production/production-plugins.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Define and activate global plugins.
+ */
+define('PRODUCTION_PLUGINS', array(
+  'google-site-kit/google-site-kit.php',
+));

--- a/wp-content/mu-plugins/the-world-site-config/configs/production/staging-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/production/staging-config.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Configuration for staging environment.
+ */
+
+/**
+ * Define and activate global plugins.
+ */
+$staging_plugins = array();
+
+tw_activate_plugins($staging_plugins);
+
+/**
+ * Configure activated plugins below.
+ */

--- a/wp-content/mu-plugins/the-world-site-config/dev-specific-configs.php
+++ b/wp-content/mu-plugins/the-world-site-config/dev-specific-configs.php
@@ -1,5 +1,0 @@
-<?php
-    # Set the WP-CFM environment
-    add_filter( 'the_world_site_config', 'dev' );
-    # Disable jetpack_development_mode
-    add_filter( 'jetpack_development_mode', '__return_true' );

--- a/wp-content/mu-plugins/the-world-site-config/includes/plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/includes/plugins.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Define helper functions to manage plugins.
+ */
+
+/**
+ * Require WP plugins helpers.
+ */
+require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+
+/**
+ * Helper to activate a list of plugins. Only activates inactive plugins.
+ */
+function tw_activate_plugins($plugins) {
+  foreach ($plugins as $plugin) {
+    if(is_plugin_inactive($plugin)) {
+        activate_plugin($plugin);
+    }
+  }
+}
+
+/**
+ * Helper to deactivate a list of plugins. Only deactivates active plugins.
+ */
+function tw_deactivate_plugins($plugins) {
+  foreach ($plugins as $plugin) {
+    if(is_plugin_active($plugin)) {
+       deactivate_plugins($plugin);
+    }
+  }
+}

--- a/wp-content/mu-plugins/the-world-site-config/live-specific-configs.php
+++ b/wp-content/mu-plugins/the-world-site-config/live-specific-configs.php
@@ -1,3 +1,0 @@
-<?php
-    # Disable jetpack_development_mode
-    add_filter( 'jetpack_development_mode', '__return_false' );

--- a/wp-content/mu-plugins/the-world-site-config/the-world-site-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/the-world-site-config.php
@@ -33,7 +33,7 @@ require_once(dirname(__FILE__) . '/configs/global/global-plugins.php');
 $plugins_to_activate = array_merge($plugins_to_activate, GLOBAL_PLUGINS);
 
 // Get production plugins.
-if ( in_array( $_ENV['WP_ENVIRONMENT_TYPE'], array( 'staging', 'production' ) ) ){
+if ( in_array( getenv('WP_ENVIRONMENT_TYPE'), array( 'staging', 'production' ) ) ){
   require_once(dirname(__FILE__) . '/configs/production/production-plugins.php');
   $plugins_to_activate = array_merge($plugins_to_activate, PRODUCTION_PLUGINS);
 }
@@ -61,7 +61,7 @@ require_once(dirname(__FILE__) . '/configs/global/global-config.php');
  * - Staging
  * - Production
 */
-if ( in_array( $_ENV['WP_ENVIRONMENT_TYPE'], array( 'staging', 'production' ) ) ){
+if ( in_array( getenv('WP_ENVIRONMENT_TYPE'), array( 'staging', 'production' ) ) ){
   require_once(dirname(__FILE__) . '/configs/production/production-config.php');
 }
 /**

--- a/wp-content/mu-plugins/the-world-site-config/the-world-site-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/the-world-site-config.php
@@ -1,29 +1,74 @@
 <?php
-/*
- Plugin Name: The World Site Config
- Plugin URI: https://pantheon.io/docs/environment-specific-config
- Description: Activates and deactivates plugins based on environment.
- Version: 1.0
- Author: Joe Tower
- Text Domain: the_world_site_config
- *
+/**
  * @package the_world_site_config
+ */
+/*
+Plugin Name: The World Site Config
+Plugin URI: https://pantheon.io/docs/environment-specific-config
+Description: Activates and deactivates plugins based on environment.
+Version: 1.1
+Author: Joe Tower, Rick Peterman
+Text Domain: the_world_site_config
 */
 
-// If this file is called directly, abort.
+/**
+ * If this file is called directly, abort.
+ */
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-# Ensuring that this is on Pantheon or Lando (Pantheon recipe) environment
-if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+/**
+ * Require plugins helpers so configs can manage plugins.
+ */
+require_once(dirname(__FILE__) . '/includes/plugins.php');
 
-  // Enable production specific config for the test and live environments.
-  if ( in_array( PANTHEON_ENVIRONMENT, array('test', 'live' ) ) ){
-    require_once( 'site-config/live-specific-configs.php' );
-  }
-  // Enable dev specific config for dev, multidevs, and lando environments.
-  else {
-    require_once( 'site-config/dev-specific-configs.php' );
-  }
+/**
+ * Gather plugins to activate.
+ */
+$plugins_to_activate = array();
+
+// Get global plugins.
+require_once(dirname(__FILE__) . '/configs/global/global-plugins.php');
+$plugins_to_activate = array_merge($plugins_to_activate, GLOBAL_PLUGINS);
+
+// Get production plugins.
+if ( in_array( $_ENV['WP_ENVIRONMENT_TYPE'], array( 'staging', 'production' ) ) ){
+  require_once(dirname(__FILE__) . '/configs/production/production-plugins.php');
+  $plugins_to_activate = array_merge($plugins_to_activate, PRODUCTION_PLUGINS);
+}
+// Get development plugins.
+else {
+  require_once(dirname(__FILE__) . '/configs/development/development-plugins.php');
+  $plugins_to_activate = array_merge($plugins_to_activate, DEVELOPMENT_PLUGINS);
+}
+
+// Activate plugins.
+tw_activate_plugins($plugins_to_activate);
+
+// Deactivate all other plugins.
+$all_plugins = array_keys(get_plugins());
+$plugins_to_deactivate = array_diff($all_plugins, $plugins_to_activate);
+tw_deactivate_plugins($plugins_to_deactivate);
+
+/**
+ * Enable global configs.
+ */
+require_once(dirname(__FILE__) . '/configs/global/global-config.php');
+
+/**
+ * Enable production environment configs.
+ * - Staging
+ * - Production
+*/
+if ( in_array( $_ENV['WP_ENVIRONMENT_TYPE'], array( 'staging', 'production' ) ) ){
+  require_once(dirname(__FILE__) . '/configs/production/production-config.php');
+}
+/**
+ * Enable development environment configs.
+ * - Local
+ * - Development
+*/
+else {
+  require_once(dirname(__FILE__) . '/configs/development/development-config.php');
 }


### PR DESCRIPTION
Closes #24 

- Update the-world-site-config mu-plugin to manage and enforce active/inactive plugins.
- Add config constants to define server platform name and env variable name.
- Update wp-config to use config constants to load sever platform config files.
- Update wp-config to load configs based on `WP_ENVIRONMENT_TYPE` instead of `PANTHEON_ENVIRONMENT`.

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Go to http://the-world-wp.lndo.site/wp-admin.
- [ ] Log in with your account or the `local-admin` created for you.

> ...then...

- [ ] Endure site loads without any errors.
- [ ] Go to Plugins.
- [ ] Ensure the only plugins that are active are those found in env plugin files in the  `/wp-content/mu-plugins/the-world-site-config` mu-plugin. Currently only the global plugins should be activated.
- [ ] Activate a plugin.
- [ ] Note that the plugin is forced back to deactivated state. (Code is now the only way to activate/deactivate plugins.)
- [ ] Code review