### PR TITLE
#59 Install and enable wp-rest-menu

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -37,6 +37,7 @@ define(
 		'wordpress-importer/wordpress-importer.php',
 		'wp-cfm-path/wp-cfm-path.php',
 		'wp-cfm/wp-cfm.php',
+		'wp-rest-menu/wp-rest-menus.php',
 		'xml-sitemap-feed/xml-sitemap.php',
 	)
 );

--- a/wp-content/plugins/wp-rest-menu/includes/class-webfiou-wp-rest-menus-controller.php
+++ b/wp-content/plugins/wp-rest-menu/includes/class-webfiou-wp-rest-menus-controller.php
@@ -1,0 +1,427 @@
+<?php
+
+namespace Webfiou;
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+use WP_REST_Controller;
+
+/**
+ * Class WP_REST_Menus_Controller
+ *
+ *
+ * @package Skapator
+ */
+class WP_REST_Menus_Controller extends WP_REST_Controller
+{
+
+    /**
+     * @var string $namespace
+     */
+    protected $namespace = 'menus/v1';
+
+    /**
+     * @var WP_REST_Menus_Controller
+     */
+    protected static $instance;
+
+    public function __construct() {}
+
+    /**
+     * Get instance of class
+     *
+     * @return WP_REST_Menus_Controller
+     */
+    public static function instance() {
+        if ( !isset( self::$instance ) && !( self::$instance instanceof WP_REST_Menus_Controller ) ) {
+            self::$instance = new WP_REST_Menus_Controller;
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Register the routes. 
+     * 
+     */
+    public function register_routes() {
+        // Get all menus
+        register_rest_route($this->namespace, '/menus', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_menus'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_menus/permissions', '__return_true', $request);
+            },
+        ));
+
+        // Get all menu locations
+        // DEPRECATED
+        register_rest_route( $this->namespace, '/menus/locations', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_menu_locations'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_menu_locations/permissions', '__return_true', $request);
+            },
+        ));
+        // REPLACEMENT
+        register_rest_route( $this->namespace, '/locations', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_menu_locations'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_menu_locations/permissions', '__return_true', $request);
+            },
+        ));
+
+        // Get menu by term_id
+        register_rest_route( $this->namespace, '/menus/(?P<id>[0-9(-]+)', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_menu_items'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_menu_items/permissions', '__return_true', $request);
+            },
+            'args' => array(
+                'id' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_menu_items/validate/args/id', is_numeric($param), $param, $request, $key);
+                    }
+                ),
+                'fields' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_menu_items/validate/args/fields', is_string($param), $param, $request, $key);
+                    }
+                ),
+                'nested' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_menu_items/validate/args/nested', absint($param), $param, $request, $key);
+                    }
+                ),
+            ),
+        ));
+
+        // Get menu by location slug
+        // DEPRECATED
+        register_rest_route( $this->namespace, '/menus/locations/(?P<slug>[a-zA-Z(-]+)', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_location_menu_items'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_location_menu_items/permissions', '__return_true', $request);
+            },
+            'args' => array(
+                'slug' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/slug', is_string($param), $param, $request, $key);
+                    }
+                ),
+                'fields' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/fields', is_string($param), $param, $request, $key);
+                    }
+                ),
+                'nested' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/nested', absint($param), $param, $request, $key);
+                    }
+                ),
+            ),
+        ));
+        // REPLACEMENT
+        register_rest_route( $this->namespace, '/locations/(?P<slug>[a-zA-Z(-]+)', array(
+            'methods'  => \WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_location_menu_items'),
+            'permission_callback' => function (\WP_REST_Request $request) {
+                return apply_filters('wprm/get_location_menu_items/permissions', '__return_true', $request);
+            },
+            'args' => array(
+                'slug' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/slug', is_string($param), $param, $request, $key);
+                    }
+                ),
+                'fields' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/fields', is_string($param), $param, $request, $key);
+                    }
+                ),
+                'nested' => array(
+                    'validate_callback' => function ($param, $request, $key) {
+                        return apply_filters('wprm/get_location_menu_items/validate/args/nested', absint($param), $param, $request, $key);
+                    }
+                ),
+            ),
+        ));
+    }
+
+    /**
+     * Get all menus
+     *
+     * @todo Separate ACF and native custom_fields, separate get meta concern
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+     */
+    public function get_menus() {
+        $args = apply_filters(
+            'wprm/get_menus/wp_get_nav_menus/args',
+            array('taxonomy' => 'nav_menu', 'hide_empty' => true, 'suppress_filters' => false)
+        );
+
+        $menus = wp_get_nav_menus( $args );
+
+        if (!$menus)
+            return rest_ensure_response( null );
+
+        $menus = $this->remove_duplicate_menus( $menus );
+
+        foreach ($menus as $menu) {
+            $menu->acf = new \stdClass();
+
+            if ( class_exists('acf') ) {
+                if ( $acf_fields = get_fields( $menu ) ) {
+                    
+                    foreach ($acf_fields as $key => $val) {
+                        if ($key[0] !== '_') {
+                            $menu->acf->$key = $val ?: null;
+                        }
+                    }
+                }
+            }
+            
+            $menu->meta = new \stdClass();
+
+            if ( $term_meta = get_term_meta( $menu->term_id, null, true) ) {
+                foreach ($term_meta as $key => $val) {
+                    if ( $key[0] !== '_' && !isset( $menu->acf->$key ) ) {
+                        $menu->meta->$key = $val;
+                    }
+                }
+            }
+        }
+
+        $menus_data = apply_filters('wprm/get_menus', $menus);
+
+        return rest_ensure_response($menus_data);
+    }
+
+    /**
+     * WPML adds duplicate menus (for a reason)
+     *
+     * @see https://wpml.org/forums/topic/using-wp_get_nav_menus-wpml-duplicate-menus-in-the-array/
+     * @param Array $menus
+     * @return Array $unique_menus
+     */
+    private function remove_duplicate_menus( $menus ) {
+        $duplicate_menu_ids = [];
+        $unique_menus = [];
+
+        foreach ( $menus as $menu ) {
+            if ( !in_array( $menu->term_id, $duplicate_menu_ids ) ) {
+                $unique_menus[] = $menu;
+            }
+
+            $duplicate_menu_ids[] = $menu->term_id;
+        }
+
+        return $unique_menus;
+    }
+
+    /**
+     * Get menu locations
+     *
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+     */
+    public function get_menu_locations() {
+        $locations = [];
+
+        foreach ( get_registered_nav_menus() as $slug => $description ) {
+            $obj = new \stdClass;
+            $obj->slug = $slug;
+            $obj->description = $description;
+            $locations[] = $obj;
+        }
+
+        $locations_data = apply_filters( 'wprm/get_menu_locations', $locations );
+
+        return rest_ensure_response( $locations_data );
+    }
+
+    /**
+     * Get menu items
+     *
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+     */
+    public function get_menu_items( \WP_REST_Request $request ) {
+        $menu = null;
+        $id = (int) $request->get_param('id');
+
+        // If WPML is active we can get the translated id for the current language
+        // by passing any lang id
+        // $id = apply_filters( 'wpml_object_id', (int) $request->get_param( 'id' ), 'nav_menu', true );
+
+        if ($menu_items = wp_get_nav_menu_items($id)) {
+            $menu = $this->get_item_fields($request, $menu_items);
+        }
+
+        $menu_data = apply_filters('wprm/get_menu_items', $menu);
+
+        return rest_ensure_response($menu_data);
+    }
+
+    /**
+     * Get menu location items
+     *
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+     */
+    public function get_location_menu_items( \WP_REST_Request $request ) {
+        $menu = null;
+
+        if ( ($locations = get_nav_menu_locations() ) && isset( $locations[$request->get_param('slug')] ) ) {
+            $menu = get_term( $locations[$request->get_param('slug')] );
+            if ( $menu_items = wp_get_nav_menu_items($menu->term_id) ) {
+                $menu = $this->get_item_fields( $request, $menu_items );
+            }
+        }
+
+        $menu_data = apply_filters( 'wprm/get_location_menu_items', $menu );
+
+        return rest_ensure_response( $menu_data );
+    }
+
+    /**
+     * Get menu item response fields
+     *
+     * @return array
+     */
+    private function get_item_fields( \WP_REST_Request $request, $menu_items ) {
+        $menu = [];
+        $nested = $this->nested_request($request);
+
+        $menu_items = apply_filters( 'wprm/get_item_fields/menu_items', $menu_items, $request );
+
+        foreach ( $menu_items as $item ) {
+            $custom_fields = $this->get_item_meta( $item->ID );
+            $item->meta = $custom_fields['meta'];
+            $item->acf = $custom_fields['acf'];
+            
+            // Add a filter so we can filter fields programatically
+            $fields = apply_filters('wprm/get_item_fields/filter_fields', $this->filter_fields( $request ), $request);
+
+            if ( $fields ) {
+                $filtered = new \stdClass;
+                foreach ( $item as $key => $val ) {
+                    if ( in_array( $key, $fields ) ) {
+                        $filtered->$key = $item->$key;
+                    }
+
+                    $filtered->ID = $item->ID;
+                    $filtered->menu_item_parent = $item->menu_item_parent;
+                }
+            } else {
+                $filtered = $item;
+            }
+
+            $menu[] = $filtered;
+        }
+
+        if ( $nested ) {
+            $menu = $this->nest_items($menu);
+        }
+
+        return $menu;
+    }
+
+    /**
+     * Nest children items in parent
+     *
+     * @return array
+     */
+    private function nest_items( $menu_items ) {
+        $parents = array_values(
+            array_filter( $menu_items, function ($m) {
+                return $m->menu_item_parent == 0;
+            })
+        );
+
+        foreach ( $parents as $parent ) {
+            $parent->children = null;
+
+            $children = array_filter( $menu_items, function ( $m ) use ( $parent ) {
+                return $m->menu_item_parent == $parent->ID;
+            });
+
+            if ( $children ) {
+                $parent->children = array_values( $children );
+            }
+        }
+
+        $parents_data = apply_filters( 'wprm/nest_items', $parents );
+
+        return $parents_data;
+    }
+
+    private function nested_request( \WP_REST_Request $request )
+    {
+        return ($request->get_param('nested') && $request->get_param('nested') == 1) || false;
+    }
+
+    /**
+     * Get item custom fields except built in
+     *
+     * TODO: Add meta field filter
+     * @return array
+     */
+    private function get_item_meta( $item_id ) {
+        
+        $acf = new \stdClass();
+        $meta = new \stdClass();
+
+        if ( class_exists('acf') ) {
+            if ( $acf_fields = get_fields( $item_id ) ) {
+                foreach ($acf_fields as $key => $field) {
+                    if ($key[0] !== '_') {
+                        $acf->$key = $field ?: null;
+                    }
+                }
+            }
+        }
+
+        
+
+        if ( $post_meta = get_post_custom( $item_id ) ) {
+            foreach ( $post_meta as $key => $val ) {
+                if ( $key[0] !== '_' && !isset( $acf->$key ) ) {
+                    $meta->$key = $val[0] ?: null;
+                }
+            }
+        }
+        
+        return [ 'acf' => $acf, 'meta' => $meta ];
+    }
+
+    /**
+     * Get filters if set
+     *
+     * @return mixed array|boolean
+     */
+    private function filter_fields( $request )
+    {
+        $fields = (string) $request->get_param('fields');
+
+        if ($fields = (string) $request->get_param('fields')) {
+            $array = explode(',', $fields);
+            return !empty( $array ) ? $array : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Visual log, print_r wrapper
+     *
+     */
+    public function log($data)
+    {
+        echo '<pre style="background:#eee;padding:5px;margin-bottom:15px">';
+        print_r($data);
+        echo '</pre>';
+    }
+}

--- a/wp-content/plugins/wp-rest-menu/includes/index.php
+++ b/wp-content/plugins/wp-rest-menu/includes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/wp-content/plugins/wp-rest-menu/index.php
+++ b/wp-content/plugins/wp-rest-menu/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/wp-content/plugins/wp-rest-menu/readme.txt
+++ b/wp-content/plugins/wp-rest-menu/readme.txt
@@ -1,0 +1,285 @@
+=== WP REST Menus ===
+Contributors: skapator
+Tags: wp-rest-menus, wp-rest-api, v2, api, wp-rest-menus, wp-api-menus, json-rest-api, menu-api-routes, menus, REST, wp-api, wp-json, acf, wpml, polylang
+Requires at least: 5.0
+Tested up to: 5.9
+Requires PHP: 5.6
+Stable tag: 1.0.4
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Add menus endpoints to WP REST API
+
+== Description ==
+
+This plugin adds new endpoints for WordPress registered menus.
+Usefull when building SPAs with Vuejs, React or any front-end framework.
+Works with Advacned Custom Fields, WPML, Polylang
+
+The new endpoints available:
+
+**Get all menus**
+`
+GET /menus/v1/menus
+
+// Response sample
+{  
+    term_id: 2,
+    name: "Main Menu",
+    slug: "main-menu",
+    term_group: 0,
+    term_taxonomy_id: 2,
+    taxonomy: "nav_menu",
+    description: "",
+    parent: 0,
+    count: 8,
+    filter: "raw"
+},
+...
+`
+
+**Get a menus items by id (term_id)**
+`
+GET /menus/v1/menus/<id>
+
+// Response sample
+{  
+    ID: 5,
+    post_author: "1",
+    post_date: "2018-07-03 06:42:18",
+    post_date_gmt: "2018-07-03 06:42:18",
+    filter: "raw",
+    db_id:5,
+    menu_item_parent: "0",
+    object_id: "5",
+    object: "custom",
+    type: "custom",
+    type_label: "Custom Link",
+    title: "Home",
+    url: "https:\/\/wp-rest-menu.local\/",
+    target: "",
+    attr_title: "",
+    description: "",
+    classes: [  
+     ""
+    ],
+    xfn: "",
+    meta: null
+},
+...
+`
+
+**Get all menu locations**
+All menu locations assigned  in /wp-admin/nav-menus.php?action=locations
+`
+GET /menus/v1/menus/locations is deprecated and will be removed in newer versions use:
+GET /menus/v1/locations
+
+// Response example
+{  
+    slug: "top",
+    description: "Top Menu"
+},
+{  
+    slug: "social",
+    description: "Social Links Menu"
+}
+...
+`
+
+**Get all menu location items**
+All menu locations assigned in /wp-admin/nav-menus.php?action=locations
+`
+GET /menus/v1/menus/locations/<slug> is deprecated and will be removed in newer versions use:
+GET /menus/v1/locations/<slug>
+
+// Response samexampleple
+{  
+    ID: 5,
+    post_author: "1",
+    post_date: "2018-07-03 06:42:18",
+    post_date_gmt: "2018-07-03 06:42:18",
+    filter: "raw",
+    db_id:5,
+    menu_item_parent: "0",
+    object_id: "5",
+    object: "custom",
+    type: "custom",
+    type_label: "Custom Link",
+    title: "Home",
+    url: "https:\/\/wp-rest-menu.local\/",
+    target: "",
+    attr_title: "",
+    description: "",
+    classes: [  
+     ""
+    ],
+    xfn: "",
+    meta: null
+},
+...
+`
+
+There are two filters availiable:
+
+**Fields Filter**
+`
+// it will return only the fields specified
+GET /menus/v1/menus/<id>/?fields=ID,title,meta
+
+// Response sample
+// Response sample
+{  
+    ID: 5,
+    title: "Home",
+    meta: null
+},
+...
+`
+
+**Nested Items Filter**
+`
+// it will return menu items parents and nested children in a 'children' field
+// Currently only one level deep is supported
+GET /menus/v1/menus/<id>/?nested=1
+
+// Response sample
+{  
+  ID: 1716,
+  menu_item_parent: "0",
+  object_id: "174",
+  object: "page",
+  title: "Level 1",
+  meta: {  
+     vue_component: "LevelComponent",
+     menu-item-field-01: "Field 1 value",
+     menu-item-field-02: "Field 2 value"
+  },
+  children:[  
+     {  
+        ID: 1717,
+        menu_item_parent: "1716",
+        object_id: "744",
+        object: "page",
+        title: "Level 2b",
+        meta : {  
+           vue_component: null
+        }
+     },
+     ...
+  ]
+},
+...
+`
+
+**WP filter hooks**
+
+This plugin is quite configurable and provides lots of wp filter hooks from returned data in responses for each endpoint to params validation and endpoint permissions.
+
+`
+add_filter( 'wprm/get_menus/wp_get_nav_menus/args', 'my_wp_get_nav_menus', 10, 1 );
+(used in GET /menus/v1/menus)
+
+function my_wp_get_nav_menus( $args ) {
+    // do something with wp_get_nav_menus $args array
+    return $args;
+}
+`
+
+`
+add_filter( 'wprm/get_menus', 'my_get_menus', 10, 1 );
+(used in GET /menus/v1/menus)
+
+function my_get_menus( $menus ) {
+    // do something with $menus array
+
+    return $menus; // WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+}
+`
+
+`
+add_filter( 'wprm/get_menu_locations', 'my_get_menu_locations', 10, 1 );
+(used in GET /menus/v1/locations)
+
+function my_get_menu_locations( $locations ) {
+    // You can modify the $locations array response (get_registered_nav_menus())
+    
+    return $locations; // WP_Error|WP_HTTP_Response|WP_REST_Response|mixed
+}
+`
+
+`
+add_filter( 'wprm/get_menu_items', 'my_get_menu_items', 10, 1 );
+(used in GET /menus/v1/menus/<id>)
+
+function my_rest_menu_item_fields( $menu ) {
+    // You can modify the $menu items
+
+    return $menu;
+}
+`
+
+`
+add_filter( 'wprm/get_location_menu_items', 'my_get_location_menu_items', 10, 1 );
+(used in GET /menus/v1/menus/<id>)
+
+function my_get_location_menu_items( $menu ) {
+    // You can modify the locations $menu items
+
+    return $menu;
+}
+`
+
+`
+add_filter( 'wprm/get_item_fields/filter_fields', 'my_filter_fields', 10, 1 );
+(used to filter return field -node edges-)
+
+function my_filter_fields( $fields ) {
+    // You can modify the $fields array so
+    // you can filter the return fields for all endpoints
+    // without using the url param ?fields
+    
+    $fields = array( 'ID', 'title' );
+    return $fields;
+}
+`
+
+More filters
+`
+apply_filters('wprm/get_menus/permissions', '__return_true', $request );
+apply_filters('wprm/get_menu_locations/permissions', '__return_true', $request );
+apply_filters('wprm/get_menu_items/permissions', '__return_true', $request );
+apply_filters('wprm/get_menu_items/validate/args/id', is_numeric( $param ), $param, $request, $key );
+apply_filters('wprm/get_menu_items/validate/args/fields', is_string( $param ), $param, $request, $key );
+apply_filters('wprm/get_menu_items/validate/args/nested', absint( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/permissions', '__return_true', $request );
+apply_filters('wprm/get_location_menu_items/validate/args/slug', is_string( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/validate/args/fields', is_string( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/validate/args/nested', absint( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/permissions', '__return_true', $request );
+apply_filters('wprm/get_location_menu_items/validate/args/slug', is_string( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/validate/args/fields', is_string( $param ), $param, $request, $key );
+apply_filters('wprm/get_location_menu_items/validate/args/nested', absint( $param ), $param, $request, $key );
+`
+
+
+Supports custom fields and Advanced Custom Fields
+If ACF is installed the response node edge is *acf* else *meta*
+In newer version these two edges will co exist and the plugin will separate natively registered custom fields ad acf registered ones.
+
+== Installation ==
+
+There are no requirements other than Wordpress and one active menu. Installation is simple:
+
+1. Upload the `wp-rest-menus` folder to the `/wp-content/plugins/` directory
+2. Activate the plugin through the 'Plugins' menu in WordPress
+
+== Frequently Asked Questions ==
+
+= How do I use this plugin? =
+
+It creates endpoints for wp nav menus to use in your front end.
+
+= Can I contribute? =
+
+Yes, you can fork it on [github](https://github.com/kostasxyz/wp-rest-menus).

--- a/wp-content/plugins/wp-rest-menu/wp-rest-menus.php
+++ b/wp-content/plugins/wp-rest-menu/wp-rest-menus.php
@@ -1,0 +1,30 @@
+<?php 
+/*
+Plugin Name: WP REST Menu
+Version: 1.0.4
+Requires at least: 5.0
+Tested up to: 5.9
+Description: Adds menu endpoints to WP REST API, filters json fields optionaly and provides an additional nested parent-child endpoint.
+Author: Kostas Charalampidis <skapator@gmail.com>
+Author URI: https://noveldigital.pro
+Plugin URI: https:/noveldigital.pro
+License: GPL2
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+*/
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+//Get required dependencies.
+require plugin_dir_path( __FILE__ ) . '/includes/class-webfiou-wp-rest-menus-controller.php';
+
+// Init rest menus class.
+function webfiou_wp_rest_menus_init() {
+    \Webfiou\WP_REST_Menus_Controller::instance()
+        ->register_routes();
+}
+
+// Hook in rest api init
+add_action( 'rest_api_init', 'webfiou_wp_rest_menus_init' );


### PR DESCRIPTION
Closes #59 

- Installs WP REST menu
- I added all the menus and items to the live env (the latest db backup from live will include the items)

## To Review

- [ ] Checkout Branch.
- [ ] Download the latest db from live
- [ ] Run `npm run refresh` 
- [ ] Go to http://the-world-wp.lndo.site/wp-admin/nav-menus.php.

> ...then...

- [ ] Confirm Menus have been created
- [ ] Check wp-json response.
