### PR TITLE
#91 Disable Custom Post Type UI plugin

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/development/development-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/development/development-plugins.php
@@ -8,6 +8,7 @@
 define(
 	'DEVELOPMENT_PLUGINS',
 	array(
+		// 'custom-post-type-ui/custom-post-type-ui.php',
 		'fg-drupal-to-wp-premium/fg-drupal-to-wp-premium.php',
 		'fg-drupal-to-wp-premium-entityreference-module/fg-drupal-to-wp-entityreference.php',
 		'fg-drupal-to-wp-premium-fieldcollection-module/fg-drupal-to-wp-fieldcollection.php',
@@ -17,4 +18,3 @@ define(
 		'pri-external-attachment/pri-external-attachment.php',
 	)
 );
-

--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -11,7 +11,6 @@ define(
 		'wp-native-php-sessions/pantheon-sessions.php',
 		'advanced-custom-fields-pro/acf.php',
 		'acf-to-rest-api/class-acf-to-rest-api.php',
-		'custom-post-type-ui/custom-post-type-ui.php',
 		'disable-comments/disable-comments.php',
 		'genesis-custom-blocks/genesis-custom-blocks.php',
 		'PATCH-external-media-without-import/external-media-without-import.php',


### PR DESCRIPTION
Closes #91 

- Moves Custom Post Type UI plugin to development and commented it out. We can turn it on when we need it.

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Go to http://the-world-wp.lndo.site/.

> ...then...

- [ ] Verify taxonomy fields
