### PR TITLE
Add a wp cli command to read amazon images and fix their sizes

### DIFF
--- a/wp-content/plugins/fg-drupal-to-wp-premium/admin/class-fg-drupal-to-wp-admin.php
+++ b/wp-content/plugins/fg-drupal-to-wp-premium/admin/class-fg-drupal-to-wp-admin.php
@@ -1315,11 +1315,11 @@ SQL;
 					$this->taxonomy_term_hierarchy = $this->get_taxonomy_term_hierarchy();
 
 					// DINKUM: exclude categories.
-					if ( ! in_array( 'categories', $this->premium_options['taxonomies_to_skip'] ) ) {
+					if ( $this->premium_options['taxonomies_to_skip'] === null || ! in_array( 'categories', $this->premium_options['taxonomies_to_skip'] ) ) {
 						$cat_count = $this->import_taxonomies_terms( 'categories' );
 						$this->display_admin_notice( sprintf( _n( '%d category imported', '%d categories imported', $cat_count, 'fg-drupal-to-wp' ), $cat_count ) );
 					}
-					if ( ! in_array( 'tags', $this->premium_options['taxonomies_to_skip'] ) ) {
+					if ( $this->premium_options['taxonomies_to_skip'] === null || ! in_array( 'tags', $this->premium_options['taxonomies_to_skip'] ) ) {
 						$tags_count = $this->import_taxonomies_terms( 'tags' );
 						$this->display_admin_notice( sprintf( _n( '%d tag imported', '%d tags imported', $tags_count, 'fg-drupal-to-wp' ), $tags_count ) );
 					}

--- a/wp-content/plugins/pri-migration-helper/cli/cli.php
+++ b/wp-content/plugins/pri-migration-helper/cli/cli.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * WP CLI module.
+ *
+ * Commands: (base) tw-fix
+ * 1. get_unprocessed_images
+ * 2. get_images_count
+ * 3. image_fix [all|new] [limit]
+ *
+ */
+
+// Add 'tw-media-fix-all' command to wp-cli.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+	require_once PMH_CLI_DIR . '/includes/class-pmh-worker.php';
+
+	$o_pmh_worker = new PMH_Worker();
+
+	WP_CLI::add_command( 'tw-fix', $o_pmh_worker );
+}

--- a/wp-content/plugins/pri-migration-helper/migration/migration.php
+++ b/wp-content/plugins/pri-migration-helper/migration/migration.php
@@ -494,3 +494,19 @@ function wpse70000_add_excerpt() {
 function pri_migration_test_codes() {
 }
 // add_action( 'init', 'pri_migration_test_codes' );
+
+/**
+ * Hook into fgd2wp_post_import and add media fix process.
+ */
+function pri_post_import_media_fix() {
+
+	// Initialize media fix cli object.
+	$o_media_fix_cli = new PMH_Worker();
+
+	// Media fix arguments.
+	$a_media_fix_arguments = array( 'new', 50 );
+
+	// Run media fix.
+	$o_media_fix_cli->image_fix( $a_media_fix_arguments );
+}
+add_action( 'fgd2wp_post_import', 'pri_post_import_media_fix', 100 );

--- a/wp-content/plugins/pri-migration-helper/pri-migration-helper.php
+++ b/wp-content/plugins/pri-migration-helper/pri-migration-helper.php
@@ -33,6 +33,7 @@ function pmh_define_constants() {
 	pmh_define_constant( 'PMH_ADMIN_DIR', plugin_dir_path( __FILE__ ) . '/admin' );
 	pmh_define_constant( 'PMH_MIGRATION_DIR', plugin_dir_path( __FILE__ ) . '/migration' );
 	pmh_define_constant( 'PMH_TEST_DIR', plugin_dir_path( __FILE__ ) . '/test' );
+	pmh_define_constant( 'PMH_CLI_DIR', plugin_dir_path( __FILE__ ) . '/cli' );
 }
 
 pmh_define_constants();
@@ -45,3 +46,6 @@ require_once plugin_dir_path( __FILE__ ) . 'migration/migration.php';
 
 // JSON tester.
 require_once plugin_dir_path( __FILE__ ) . 'test/test.php';
+
+// CLI Feature.
+require_once plugin_dir_path( __FILE__ ) . 'cli/cli.php';


### PR DESCRIPTION
- Add a new WP CLI command that facilitates the adjustment of image sizes directly from terminal commands. Additionally, the same process has been set to trigger automatically upon a Drupal import is finished.