### PR TITLE
Enable excerpt and remove teaser acf field from episodes

### DIFF
--- a/wp-content/plugins/tw-episodes/tw-episodes.php
+++ b/wp-content/plugins/tw-episodes/tw-episodes.php
@@ -46,7 +46,7 @@ function tw_episodes_post_type() {
 		'label'               => __( 'Episodes', 'text_domain' ),
 		'description'         => __( 'Manages the Episode custom post type', 'text_domain' ),
 		'labels'              => $labels,
-		'supports'            => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+		'supports'            => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'excerpt' ),
 		'taxonomies'          => array( 'category', 'post_tag', 'tw_programs' ),
 		'hierarchical'        => false,
 		'public'              => true,

--- a/wp-content/themes/newspack-theme/acf-json/group_622a1664a8c12.json
+++ b/wp-content/themes/newspack-theme/acf-json/group_622a1664a8c12.json
@@ -6,6 +6,7 @@
             "key": "field_622a166c5d7e1",
             "label": "Teaser",
             "name": "teaser",
+            "aria-label": "",
             "type": "textarea",
             "instructions": "",
             "required": 0,
@@ -23,13 +24,6 @@
         }
     ],
     "location": [
-        [
-            {
-                "param": "post_type",
-                "operator": "==",
-                "value": "episode"
-            }
-        ],
         [
             {
                 "param": "taxonomy",
@@ -68,5 +62,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 1,
-    "modified": 1655916487
+    "modified": 1689084102
 }


### PR DESCRIPTION
- Enable excerpt for Episodes post type.
- Remove teaser ACF field from Episodes because the Drupal teaser was moved to the excerpt post field.
