### PR TITLE
Fix program taxonomy url

### DIFF
--- a/wp-content/plugins/tw-import-post-types/tw-import-post-types.php
+++ b/wp-content/plugins/tw-import-post-types/tw-import-post-types.php
@@ -101,4 +101,4 @@
 	register_post_type( "program", $args );
 }
 
-add_action( 'init', 'cptui_register_my_cpts' );
+add_action( 'init', 'cptui_register_my_cpts', 0 );


### PR DESCRIPTION
- Fix Taxonomy program slug
- Escape image url to avoid warnings when reading images with spaces in the name
