### PR TITLE
121: Add custom taxonomies to episode and segment

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -29,7 +29,7 @@ define(
 		'tw-resource-development-tags/tw-resource-development-tags.php',
 		'tw-segments/tw-segments.php',
 		'tw-story-format/tw-story-format.php',
-		'tw-import-post-types/tw-import-post-types.php', // This is the plugin that creates the custom post types for the import. Can be removed after the import is complete.
+		// 'tw-import-post-types/tw-import-post-types.php', // This is the plugin that creates the custom post types for the import. Can be removed after the import is complete.
 		'wordpress-importer/wordpress-importer.php',
 		'wordpress-seo/wp-seo.php',
 		'wp-all-export-pro/wp-all-export-pro.php',

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-city.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-city.php
@@ -59,7 +59,7 @@ function tw_city_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'city',
+		'rest_base'             => 'tags/cities',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_city_taxonomy() {
 		'graphql_single_name'   => 'city',
 		'graphql_plural_name'   => 'cities',
 	);
-	register_taxonomy( 'city', array( 'post' ), $args );
+	register_taxonomy( 'city', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_city_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-continent.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-continent.php
@@ -59,7 +59,7 @@ function tw_continent_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'continent',
+		'rest_base'             => 'tags/continents',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_continent_taxonomy() {
 		'graphql_single_name'   => 'continent',
 		'graphql_plural_name'   => 'continents',
 	);
-	register_taxonomy( 'continent', array( 'post' ), $args );
+	register_taxonomy( 'continent', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_continent_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-country.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-country.php
@@ -59,7 +59,7 @@ function tw_country_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'country',
+		'rest_base'             => 'tags/countries',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_country_taxonomy() {
 		'graphql_single_name'   => 'country',
 		'graphql_plural_name'   => 'countries',
 	);
-	register_taxonomy( 'country', array( 'post' ), $args );
+	register_taxonomy( 'country', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_country_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-person.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-person.php
@@ -59,7 +59,7 @@ function tw_person_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'person',
+		'rest_base'             => 'tags/people',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_person_taxonomy() {
 		'graphql_single_name'   => 'person',
 		'graphql_plural_name'   => 'people',
 	);
-	register_taxonomy( 'person', array( 'post' ), $args );
+	register_taxonomy( 'person', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_person_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-province-state.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-province-state.php
@@ -52,14 +52,14 @@ function tw_province_state_taxonomy() {
 		'show_in_nav_menus'     => false,
 		'query_var'             => true,
 		'rewrite'               => array(
-			'slug'         => 'tags/province_or_state',
+			'slug'         => 'tags/provinces_or_states',
 			'with_front'   => false,
 			'hierarchical' => true,
 		),
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'province_or_state',
+		'rest_base'             => 'tags/provinces_or_states',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_province_state_taxonomy() {
 		'graphql_single_name'   => 'provinceOrState',
 		'graphql_plural_name'   => 'provincesOrStates',
 	);
-	register_taxonomy( 'province_or_state', array( 'post' ), $args );
+	register_taxonomy( 'province_or_state', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_province_state_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-region.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-region.php
@@ -59,7 +59,7 @@ function tw_region_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'region',
+		'rest_base'             => 'tags/regions',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_region_taxonomy() {
 		'graphql_single_name'   => 'region',
 		'graphql_plural_name'   => 'regions',
 	);
-	register_taxonomy( 'region', array( 'post' ), $args );
+	register_taxonomy( 'region', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_region_taxonomy', 0 );

--- a/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-social-tag.php
+++ b/wp-content/plugins/tw-custom-tags/taxonomies/taxonomy-social-tag.php
@@ -59,7 +59,7 @@ function tw_social_tag_taxonomy() {
 		'show_admin_column'     => false,
 		'show_in_rest'          => true,
 		'show_tagcloud'         => false,
-		'rest_base'             => 'social_tags',
+		'rest_base'             => 'tags/social_tags',
 		'rest_controller_class' => 'WP_REST_Terms_Controller',
 		'rest_namespace'        => 'wp/v2',
 		'show_in_quick_edit'    => true,
@@ -68,6 +68,6 @@ function tw_social_tag_taxonomy() {
 		'graphql_single_name'   => 'socialTag',
 		'graphql_plural_name'   => 'socialTags',
 	);
-	register_taxonomy( 'social_tags', array( 'post' ), $args );
+	register_taxonomy( 'social_tags', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_social_tag_taxonomy', 0 );

--- a/wp-content/plugins/tw-episodes/tw-episodes.php
+++ b/wp-content/plugins/tw-episodes/tw-episodes.php
@@ -47,7 +47,7 @@ function tw_episodes_post_type() {
 		'description'         => __( 'Manages the Episode custom post type', 'text_domain' ),
 		'labels'              => $labels,
 		'supports'            => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'excerpt' ),
-		'taxonomies'          => array( 'category', 'post_tag', 'tw_programs' ),
+		'taxonomies'          => array( 'category', 'post_tag' ),
 		'rewrite'             => array(
 			'slug'       => 'episodes',
 			'with_front' => false,

--- a/wp-content/plugins/tw-segments/tw-segments.php
+++ b/wp-content/plugins/tw-segments/tw-segments.php
@@ -53,7 +53,7 @@ function tw_segments_post_type() {
 		),
 		'labels'              => $labels,
 		'supports'            => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
-		'taxonomies'          => array( 'tw_contributors', 'tw_programs' ),
+		'taxonomies'          => array( 'category', 'post_tag' ),
 		'rewrite'             => array(
 			'slug'       => 'segments',
 			'with_front' => false,


### PR DESCRIPTION
Closes #121 

- Updates tw-custom-tags taxonomies to apply to episode and segment post types.
- Updates tw-custom-tags taxonomies' rest base paths.

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Log into to http://the-world-wp.lndo.site/wp-admin.

> ...then...

- [ ] Edit a episode and ensure custom taxonomies fields are present.
- [ ] Edit a segment and ensure custom taxonomies fields are present.

