### PR TITLE
124: Add Team field to Program terms

### DIFF
--- a/wp-content/themes/the-world/acf-json/group_622a31617f10b.json
+++ b/wp-content/themes/the-world/acf-json/group_622a31617f10b.json
@@ -1,6 +1,6 @@
 {
     "key": "group_622a31617f10b",
-    "title": "Program Hosts",
+    "title": "Program Contributors",
     "fields": [
         {
             "key": "field_622a3175fb705",
@@ -16,6 +16,29 @@
                 "class": "",
                 "id": ""
             },
+            "taxonomy": "contributor",
+            "field_type": "multi_select",
+            "allow_null": 0,
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "object",
+            "multiple": 0
+        },
+        {
+            "key": "field_64da3eab034d9",
+            "label": "Team",
+            "name": "team",
+            "aria-label": "",
+            "type": "taxonomy",
+            "instructions": "Contributors selected will be shown on the program's team page. Make sure to include Hosts in this fields as well.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
             "show_in_graphql": 1,
             "taxonomy": "contributor",
             "add_term": 0,
@@ -23,7 +46,7 @@
             "load_terms": 0,
             "return_format": "id",
             "field_type": "multi_select",
-            "allow_null": 1,
+            "allow_null": 0,
             "multiple": 0
         }
     ],
@@ -34,27 +57,20 @@
                 "operator": "==",
                 "value": "program"
             }
-        ],
-        [
-            {
-                "param": "post_type",
-                "operator": "==",
-                "value": "program"
-            }
         ]
     ],
     "menu_order": 0,
     "position": "normal",
-    "style": "seamless",
-    "label_placement": "left",
+    "style": "default",
+    "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
     "description": "",
     "show_in_rest": 1,
     "show_in_graphql": 1,
-    "graphql_field_name": "programHosts",
+    "graphql_field_name": "programContributors",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1685120166
+    "modified": 1692027660
 }

--- a/wp-content/themes/the-world/acf-json/group_622a32ff021a3.json
+++ b/wp-content/themes/the-world/acf-json/group_622a32ff021a3.json
@@ -62,21 +62,21 @@
             {
                 "param": "post_type",
                 "operator": "==",
-                "value": "program"
+                "value": "post"
             }
         ],
         [
             {
                 "param": "post_type",
                 "operator": "==",
-                "value": "person"
+                "value": "post"
             }
         ]
     ],
     "menu_order": 0,
     "position": "normal",
-    "style": "seamless",
-    "label_placement": "left",
+    "style": "default",
+    "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
@@ -86,5 +86,5 @@
     "graphql_field_name": "sponsorship",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1686588888
+    "modified": 1692027764
 }


### PR DESCRIPTION
Closes #124 

- Rename "Program Hosts" field group to "Program Contributors"
- Add Team field to "Program Contributors"
- Update program fields groups presentation

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Log  into http://the-world-wp.lndo.site/wp-admin.

> ...then...

- [ ] Edit any program.
- [ ] Ensure Team field is present.
- [ ] Ensure fields groups make sense.
