### PR TITLE
#66 remove wlw manifest link from site header

### DIFF
--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -57,3 +57,4 @@ endif;
 add_action( 'template_redirect', 'tw_redirect_logged_out_to_frontend' );
 
 // Remove Windows Live Writer manifest link
+remove_action('wp_head', 'wlwmanifest_link');

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -55,3 +55,5 @@ if ( ! function_exists( 'tw_redirect_logged_out_to_frontend' ) ) :
 	}
 endif;
 add_action( 'template_redirect', 'tw_redirect_logged_out_to_frontend' );
+
+// Remove Windows Live Writer manifest link


### PR DESCRIPTION
Closes #66 

- [Removes WLW manifest link from site header](https://wpassist.me/how-to-remove-wlwmanifest-from-wordpress/)

## To Review

- [ ] Code review
