### PR TITLE
#95: don't load empty staging config file

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
@@ -16,6 +16,8 @@ add_filter( 'jetpack_development_mode', '__return_false' );
  * Load staging specific config now so it can override
  * production settings.
  */
-if ( defined('WP_ENVIRONMENT_TYPE') && WP_ENVIRONMENT_TYPE === 'staging' ) {
+/**
+ * if ( defined('WP_ENVIRONMENT_TYPE') && WP_ENVIRONMENT_TYPE === 'staging' ) {
 	require_once dirname( __FILE__ ) . '/staging-config.php';
-}
+ * }
+*/

--- a/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/production/production-config.php
@@ -16,8 +16,6 @@ add_filter( 'jetpack_development_mode', '__return_false' );
  * Load staging specific config now so it can override
  * production settings.
  */
-/**
- * if ( defined('WP_ENVIRONMENT_TYPE') && WP_ENVIRONMENT_TYPE === 'staging' ) {
+if ( getenv( WP_ENVIRONMENT_TYPE ) === 'staging' ) {
 	require_once dirname( __FILE__ ) . '/staging-config.php';
- * }
-*/
+}


### PR DESCRIPTION
Closes #95 

- To my eye it looks like loading an empty staging config file is causing a warning that may become an error down the road. This PR comments out the part that loads this file. 
- If you have another solution in looking, feel free to adjust. 