### PR TITLE
HOTFIX: admin accordion content heights

### DIFF
--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -56,5 +56,21 @@ if ( ! function_exists( 'tw_redirect_logged_out_to_frontend' ) ) :
 endif;
 add_action( 'template_redirect', 'tw_redirect_logged_out_to_frontend' );
 
+if ( ! function_exists( 'tw_admin_styles' ) ) :
+	/**
+	 * Add styles to admin.
+	 *
+	 * @return void
+	 */
+	function tw_admin_styles() {
+		// Fixes layout heights of some accordion containers after WP 6.3 update.
+		echo '<style>
+			.components-panel__body { display: grid; }
+			.wpseo-meta-section, .wpseo-meta-section-react { min-height: unset; }
+		</style>';
+	}
+endif;
+add_action( 'admin_head', 'tw_admin_styles' );
+
 // Remove Windows Live Writer manifest link
-remove_action('wp_head', 'wlwmanifest_link');
+remove_action( 'wp_head', 'wlwmanifest_link' );


### PR DESCRIPTION
- yoast container height
- categories metabox height

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Go to http://the-world-wp.lndo.site/.

> ...then...

- [ ] Edit any post and ensure Yoast and Categories metaboxes are the correct height.
