### PR TITLE
10: Create Call To Actions plugin

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -17,6 +17,7 @@ define(
 		'pwa/pwa.php',
 		'redirection/redirection.php',
 		'user-role-editor/user-role-editor.php',
+		'tw-call-to-actions/tw-call-to-actions.php',
 		'tw-contributors/tw-contributors.php',
 		'tw-custom-tags/tw-custom-tags.php',
 		'tw-disable-yoast-indexables/tw-disable-yoast-indexables.php',

--- a/wp-content/plugins/tw-call-to-actions/post-types/post-type--cta-region.php
+++ b/wp-content/plugins/tw-call-to-actions/post-types/post-type--cta-region.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: TW CTA Regions
+ * Description: Manages the CTA Region custom post type
+ *
+ * @package tw_call_to_actions
+ */
+
+/**
+ * Register CTA Regions Post Type.
+ *
+ * @return void
+ */
+function tw_call_to_actions_post_type_cta_region() {
+
+	$labels = array(
+		'name'                  => _x( 'CTA Regions', 'Post Type General Name', 'text_domain' ),
+		'singular_name'         => _x( 'CTA Region', 'Post Type Singular Name', 'text_domain' ),
+		'menu_name'             => __( 'CTA Regions', 'text_domain' ),
+		'name_admin_bar'        => __( 'CTA Regions', 'text_domain' ),
+		'archives'              => __( 'Item Archives', 'text_domain' ),
+		'attributes'            => __( 'Item Attributes', 'text_domain' ),
+		'parent_item_colon'     => __( 'Parent Item:', 'text_domain' ),
+		'all_items'             => __( 'All CTA Regions', 'text_domain' ),
+		'add_new_item'          => __( 'Add New CTA Region', 'text_domain' ),
+		'add_new'               => __( 'Add New', 'text_domain' ),
+		'new_item'              => __( 'New CTA Region', 'text_domain' ),
+		'edit_item'             => __( 'Edit CTA Region', 'text_domain' ),
+		'update_item'           => __( 'Update CTA Region', 'text_domain' ),
+		'view_item'             => __( 'View CTA Region', 'text_domain' ),
+		'view_items'            => __( 'View CTA Region', 'text_domain' ),
+		'search_items'          => __( 'Search CTA Region', 'text_domain' ),
+		'not_found'             => __( 'Not found', 'text_domain' ),
+		'not_found_in_trash'    => __( 'Not found in Trash', 'text_domain' ),
+		'featured_image'        => __( 'Featured Image', 'text_domain' ),
+		'set_featured_image'    => __( 'Set featured image', 'text_domain' ),
+		'remove_featured_image' => __( 'Remove featured image', 'text_domain' ),
+		'use_featured_image'    => __( 'Use as featured image', 'text_domain' ),
+		'insert_into_item'      => __( 'Insert into item', 'text_domain' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this item', 'text_domain' ),
+		'items_list'            => __( 'Items list', 'text_domain' ),
+		'items_list_navigation' => __( 'Items list navigation', 'text_domain' ),
+		'filter_items_list'     => __( 'Filter items list', 'text_domain' ),
+	);
+	$args   = array(
+		'label'               => __( 'CTA Regions', 'text_domain' ),
+		'description'         => __( 'Manages the CTA Region custom post type', 'text_domain' ),
+		'labels'              => $labels,
+		'supports'            => array( 'title', 'excerpt' ),
+		'taxonomies'          => array( 'cta_region_types' ),
+		'rewrite'             => array(
+			'slug'       => 'cta_regions',
+			'with_front' => false,
+		),
+		'hierarchical'        => false,
+		'public'              => false,
+		'publicly_queryable'  => true,
+		'show_ui'             => true,
+		'show_in_menu'        => true,
+		'menu_position'       => 21,
+		'menu_icon'           => 'dashicons-align-right',
+		'show_in_admin_bar'   => true,
+		'show_in_nav_menus'   => false,
+		'can_export'          => false,
+		'has_archive'         => false,
+		'exclude_from_search' => false,
+		'capability_type'     => array( 'cta_region', 'cta_regions' ),
+		'capabilities'        => array(
+			'create_posts' => 'create_cta_region',
+		),
+		'map_meta_cap'        => true,
+		'show_in_rest'        => true,
+		'show_in_graphql'     => true,
+		'graphql_single_name' => 'ctaRegion',
+		'graphql_plural_name' => 'ctaRegions',
+	);
+	register_post_type( 'cta_region', $args );
+
+}
+add_action( 'init', 'tw_call_to_actions_post_type_cta_region', 0 );

--- a/wp-content/plugins/tw-call-to-actions/post-types/post-type--cta.php
+++ b/wp-content/plugins/tw-call-to-actions/post-types/post-type--cta.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: TW Call To Actions
+ * Description: Manages the Call To Action custom post type
+ *
+ * @package tw_call_to_actions
+ */
+
+/**
+ * Register Call To Action (CTA) Post Type.
+ *
+ * @return void
+ */
+function tw_call_to_actions_post_type_cta() {
+
+	$labels = array(
+		'name'                  => _x( 'Call To Actions', 'Post Type General Name', 'text_domain' ),
+		'singular_name'         => _x( 'Call To Action', 'Post Type Singular Name', 'text_domain' ),
+		'menu_name'             => __( 'Call To Actions', 'text_domain' ),
+		'name_admin_bar'        => __( 'Call To Actions', 'text_domain' ),
+		'archives'              => __( 'Item Archives', 'text_domain' ),
+		'attributes'            => __( 'Item Attributes', 'text_domain' ),
+		'parent_item_colon'     => __( 'Parent Item:', 'text_domain' ),
+		'all_items'             => __( 'All Call To Actions', 'text_domain' ),
+		'add_new_item'          => __( 'Add New Call To Action', 'text_domain' ),
+		'add_new'               => __( 'Add New', 'text_domain' ),
+		'new_item'              => __( 'New Call To Action', 'text_domain' ),
+		'edit_item'             => __( 'Edit Call To Action', 'text_domain' ),
+		'update_item'           => __( 'Update Call To Action', 'text_domain' ),
+		'view_item'             => __( 'View Call To Action', 'text_domain' ),
+		'view_items'            => __( 'View Call To Action', 'text_domain' ),
+		'search_items'          => __( 'Search Call To Action', 'text_domain' ),
+		'not_found'             => __( 'Not found', 'text_domain' ),
+		'not_found_in_trash'    => __( 'Not found in Trash', 'text_domain' ),
+		'featured_image'        => __( 'Featured Image', 'text_domain' ),
+		'set_featured_image'    => __( 'Set featured image', 'text_domain' ),
+		'remove_featured_image' => __( 'Remove featured image', 'text_domain' ),
+		'use_featured_image'    => __( 'Use as featured image', 'text_domain' ),
+		'insert_into_item'      => __( 'Insert into item', 'text_domain' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this item', 'text_domain' ),
+		'items_list'            => __( 'Items list', 'text_domain' ),
+		'items_list_navigation' => __( 'Items list navigation', 'text_domain' ),
+		'filter_items_list'     => __( 'Filter items list', 'text_domain' ),
+	);
+	$args   = array(
+		'label'               => __( 'Call To Actions', 'text_domain' ),
+		'description'         => __( 'Manages the Call To Action custom post type', 'text_domain' ),
+		'labels'              => $labels,
+		'supports'            => array( 'title' ),
+		'taxonomies'          => array(),
+		'rewrite'             => array(
+			'slug'       => 'call_to_actions',
+			'with_front' => false,
+		),
+		'hierarchical'        => false,
+		'public'              => false,
+		'publicly_queryable'  => true,
+		'show_ui'             => true,
+		'show_in_menu'        => true,
+		'menu_position'       => 20,
+		'menu_icon'           => 'dashicons-align-center',
+		'show_in_admin_bar'   => true,
+		'show_in_nav_menus'   => false,
+		'can_export'          => false,
+		'has_archive'         => false,
+		'exclude_from_search' => false,
+		'capability_type'     => array( 'call_to_action', 'call_to_actions' ),
+		'capabilities'        => array(
+			'create_posts' => 'create_call_to_action',
+		),
+		'map_meta_cap'        => true,
+		'show_in_rest'        => true,
+		'show_in_graphql'     => true,
+		'graphql_single_name' => 'callToAction',
+		'graphql_plural_name' => 'callToActions',
+	);
+	register_post_type( 'call_to_action', $args );
+
+}
+add_action( 'init', 'tw_call_to_actions_post_type_cta', 0 );

--- a/wp-content/plugins/tw-call-to-actions/taxonomies/taxonomy--cta-region-type.php
+++ b/wp-content/plugins/tw-call-to-actions/taxonomies/taxonomy--cta-region-type.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Register CTA Region Type Taxonomy
+ *
+ * @package tw_call_to_actions
+ */
+
+/**
+ * Register Region Taxonomy
+ *
+ * @return void
+ */
+function tw_call_to_actions_taxonomy_cta_region_type() {
+	/**
+	 * Taxonomy: CTA Region Type.
+	 */
+
+	$labels = array(
+		'name'                       => esc_html__( 'CTA Region Types', 'newspack' ),
+		'singular_name'              => esc_html__( 'CTA Region Type', 'newspack' ),
+		'name'                       => esc_html__( 'CTA Region Types', 'newspack' ),
+		'singular_name'              => esc_html__( 'CTA Region Type', 'newspack' ),
+		'search_items'               => esc_html__( 'Search CTA Region Types', 'newspack' ),
+		'popular_items'              => esc_html__( 'Popular CTA Region Types', 'newspack' ),
+		'all_items'                  => esc_html__( 'All CTA Region Types', 'newspack' ),
+		'parent_item'                => esc_html__( 'Parent CTA Region Type', 'newspack' ),
+		'parent_item_colon'          => esc_html__( 'Parent CTA Region Type:', 'newspack' ),
+		'edit_item'                  => esc_html__( 'Edit CTA Region Type', 'newspack' ),
+		'view_item'                  => esc_html__( 'View CTA Region Type', 'newspack' ),
+		'update_item'                => esc_html__( 'Update CTA Region Type', 'newspack' ),
+		'add_new_item'               => esc_html__( 'Add New CTA Region Type', 'newspack' ),
+		'new_item_name'              => esc_html__( 'New CTA Region Type Name', 'newspack' ),
+		'separate_items_with_commas' => esc_html__( 'Separate CTA Region Types with commas', 'newspack' ),
+		'add_or_remove_items'        => esc_html__( 'Add or remove CTA Region Types', 'newspack' ),
+		'choose_from_most_used'      => esc_html__( 'Choose from the most used CTA Region Types', 'newspack' ),
+		'not_found'                  => esc_html__( 'No CTA Region Types found.', 'newspack' ),
+		'no_terms'                   => esc_html__( 'No CTA Region Types', 'newspack' ),
+		'items_list_navigation'      => esc_html__( 'CTA Region Types list navigation', 'newspack' ),
+		'items_list'                 => esc_html__( 'CTA Region Types list', 'newspack' ),
+		'menu_name'                  => esc_html__( 'CTA Region Types', 'newspack' ),
+		'name_admin_bar'             => esc_html__( 'CTA Region Types', 'newspack' ),
+	);
+
+	$args = array(
+		'label'                 => esc_html__( 'CTA Region Types', 'newspack' ),
+		'description'           => esc_html__( 'Allows for multile regions to be queries by type slug in a single request via the GraphQL API.', 'newspack' ),
+		'labels'                => $labels,
+		'public'                => false,
+		'publicly_queryable'    => true,
+		'hierarchical'          => false,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => false,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'         => '/cta_region_types',
+			'with_front'   => false,
+			'hierarchical' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'show_tagcloud'         => false,
+		'rest_base'             => 'cta_region_types',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'rest_namespace'        => 'wp/v2',
+		'show_in_quick_edit'    => true,
+		'sort'                  => false,
+		'show_in_graphql'       => true,
+		'graphql_single_name'   => 'ctaRegionType',
+		'graphql_plural_name'   => 'ctaRegionTypes',
+	);
+	register_taxonomy( 'cta_region_type', array( 'cta_region' ), $args );
+}
+add_action( 'init', 'tw_call_to_actions_taxonomy_cta_region_type', 0 );

--- a/wp-content/plugins/tw-call-to-actions/tw-call-to-actions.php
+++ b/wp-content/plugins/tw-call-to-actions/tw-call-to-actions.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Plugin Name: TW Call To Actions (CTA's)
+ * Description: Creates the custom post types and taxonomies for CTA's.
+ *
+ * @package tw_call_to_actions
+ */
+
+/**
+ * Import Taxonomy files
+ */
+require_once 'taxonomies/taxonomy--cta-region-type.php';
+
+/**
+ * Import Post Type files
+ */
+require_once 'post-types/post-type--cta.php';
+require_once 'post-types/post-type--cta-region.php';

--- a/wp-content/themes/the-world/acf-json/group_622a2d2e34139.json
+++ b/wp-content/themes/the-world/acf-json/group_622a2d2e34139.json
@@ -61,6 +61,11 @@
                 "param": "taxonomy",
                 "operator": "==",
                 "value": "all"
+            },
+            {
+                "param": "taxonomy",
+                "operator": "!=",
+                "value": "cta_region_type"
             }
         ],
         [
@@ -82,7 +87,19 @@
     "show_in_rest": 1,
     "show_in_graphql": 1,
     "graphql_field_name": "taxonomyImages",
-    "map_graphql_types_from_location_rules": 0,
-    "graphql_types": "",
-    "modified": 1685120051
+    "map_graphql_types_from_location_rules": 1,
+    "graphql_types": [
+        "Category",
+        "City",
+        "Continent",
+        "Contributor",
+        "Country",
+        "Person",
+        "Program",
+        "ProvinceOrState",
+        "Region",
+        "SocialTag",
+        "Tag"
+    ],
+    "modified": 1692816377
 }

--- a/wp-content/themes/the-world/acf-json/group_64e6466148253.json
+++ b/wp-content/themes/the-world/acf-json/group_64e6466148253.json
@@ -1,11 +1,11 @@
 {
-    "key": "group_6470dbd403806",
-    "title": "Landing Page",
+    "key": "group_64e6466148253",
+    "title": "CTA Region Content",
     "fields": [
         {
-            "key": "field_64a853f71ad05",
-            "label": "Featured Posts",
-            "name": "featured_posts",
+            "key": "field_64e649d155e32",
+            "label": "Call To Actions",
+            "name": "call_to_actions",
             "aria-label": "",
             "type": "relationship",
             "instructions": "",
@@ -18,13 +18,14 @@
             },
             "show_in_graphql": 1,
             "post_type": [
-                "post"
+                "call_to_action"
             ],
-            "post_status": "",
+            "post_status": [
+                "publish"
+            ],
             "taxonomy": "",
             "filters": [
-                "search",
-                "taxonomy"
+                "search"
             ],
             "return_format": "id",
             "min": 0,
@@ -36,14 +37,9 @@
     "location": [
         [
             {
-                "param": "taxonomy",
+                "param": "post_type",
                 "operator": "==",
-                "value": "all"
-            },
-            {
-                "param": "taxonomy",
-                "operator": "!=",
-                "value": "cta_region_type"
+                "value": "cta_region"
             }
         ]
     ],
@@ -54,23 +50,11 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": "",
+    "description": "Fields to define CTA Region content.",
     "show_in_rest": 0,
     "show_in_graphql": 1,
-    "graphql_field_name": "landingPage",
-    "map_graphql_types_from_location_rules": 1,
-    "graphql_types": [
-        "Category",
-        "City",
-        "Continent",
-        "Contributor",
-        "Country",
-        "Person",
-        "Program",
-        "ProvinceOrState",
-        "Region",
-        "SocialTag",
-        "Tag"
-    ],
-    "modified": 1692816144
+    "graphql_field_name": "ctaRegionContent",
+    "map_graphql_types_from_location_rules": 0,
+    "graphql_types": "",
+    "modified": 1692813882
 }

--- a/wp-content/themes/the-world/acf-json/group_64e658ff75bf6.json
+++ b/wp-content/themes/the-world/acf-json/group_64e658ff75bf6.json
@@ -1,0 +1,317 @@
+{
+    "key": "group_64e658ff75bf6",
+    "title": "CTA Options",
+    "fields": [
+        {
+            "key": "field_64e659020476a",
+            "label": "CTA Type",
+            "name": "cta_type",
+            "aria-label": "",
+            "type": "select",
+            "instructions": "<p>Select the type of call to action you wish to use.<\/p>\r\n<ul>\r\n<li>Informational - General information.<\/li>\r\n<li>Donation - Similar to Informational, but will be themed for donating. (Additional donation settings will come later for in app donation form configuration.)\r\n<li>Opt-In - Prompt to opt into something, such as privacy policy. Checkbox will be provided to enable action button when checked.<\/li>\r\n<li>Newsletter - Show a newsletter subscription form. Mailing List can be customized from the default Top of The World newsletter list.<\/li>\r\n<\/ul>",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "choices": {
+                "info": "Informational",
+                "donation": "Donation",
+                "optin": "Opt-In",
+                "newsletter": "Newsletter"
+            },
+            "default_value": "info",
+            "return_format": "value",
+            "multiple": 0,
+            "allow_null": 0,
+            "ui": 0,
+            "ajax": 0,
+            "placeholder": ""
+        },
+        {
+            "key": "field_64e6697f4ebba",
+            "label": "Content",
+            "name": "content",
+            "aria-label": "",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_64e65c060476c",
+                    "label": "Heading",
+                    "name": "heading",
+                    "aria-label": "",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "maxlength": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": ""
+                },
+                {
+                    "key": "field_64e65e590476d",
+                    "label": "Message",
+                    "name": "message",
+                    "aria-label": "",
+                    "type": "wysiwyg",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "tabs": "all",
+                    "toolbar": "basic",
+                    "media_upload": 0,
+                    "delay": 0
+                }
+            ]
+        },
+        {
+            "key": "field_64e66d88acc6e",
+            "label": "Actions",
+            "name": "actions",
+            "aria-label": "",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_64e66dacacc6f",
+                    "label": "Action Button Label",
+                    "name": "action_button_label",
+                    "aria-label": "",
+                    "type": "text",
+                    "instructions": "Label used in action button. Will override the default label, or create an action button for CTA types that usually do not have an default action.",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "maxlength": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": ""
+                },
+                {
+                    "key": "field_64e66eeeacc70",
+                    "label": "Action Button URL",
+                    "name": "action_button_url",
+                    "aria-label": "",
+                    "type": "url",
+                    "instructions": "URL the action button should link to. Action button will act as a dismiss button in dismissible regions when no URL is provided.",
+                    "required": 0,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_64e659020476a",
+                                "operator": "!=",
+                                "value": "optin"
+                            },
+                            {
+                                "field": "field_64e659020476a",
+                                "operator": "!=",
+                                "value": "newsletter"
+                            }
+                        ]
+                    ],
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "placeholder": ""
+                },
+                {
+                    "key": "field_64e77d55664eb",
+                    "label": "Dismiss Button Label",
+                    "name": "dismiss_button_label",
+                    "aria-label": "",
+                    "type": "text",
+                    "instructions": "Customize the label of the dismiss button. Dismiss button will only be shown in dismissible regions.",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "maxlength": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": ""
+                }
+            ]
+        },
+        {
+            "key": "field_64e77e3e664ec",
+            "label": "Opt-In Settings",
+            "name": "opt-in_settings",
+            "aria-label": "",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_64e659020476a",
+                        "operator": "==",
+                        "value": "optin"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_64e77e9a664ed",
+                    "label": "Opt-In Text",
+                    "name": "opt-in_text",
+                    "aria-label": "",
+                    "type": "wysiwyg",
+                    "instructions": "",
+                    "required": 1,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "I have read and agree to your <a href=\"https:\/\/theworld.org\/terms\" target=\"_blank\">Terms of Use<\/a>.",
+                    "tabs": "all",
+                    "toolbar": "basic",
+                    "media_upload": 0,
+                    "delay": 0
+                }
+            ]
+        },
+        {
+            "key": "field_64e7818ca4fb1",
+            "label": "Newsletter Settings",
+            "name": "newsletter_settings",
+            "aria-label": "",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_64e659020476a",
+                        "operator": "==",
+                        "value": "newsletter"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_64e781aea4fb2",
+                    "label": "Newsletter",
+                    "name": "newsletter",
+                    "aria-label": "",
+                    "type": "post_object",
+                    "instructions": "Select a Newsletter post to have sign up form settings pulled from. If a region wouldn't support a sign up form, a link to the newsletter page will be provided.",
+                    "required": 1,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "post_type": [
+                        "newsletter"
+                    ],
+                    "post_status": [
+                        "publish"
+                    ],
+                    "taxonomy": "",
+                    "return_format": "id",
+                    "multiple": 0,
+                    "allow_null": 0,
+                    "ui": 1,
+                    "bidirectional_target": []
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "call_to_action"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "acf_after_title",
+    "style": "seamless",
+    "label_placement": "top",
+    "instruction_placement": "field",
+    "hide_on_screen": [
+        "permalink",
+        "slug"
+    ],
+    "active": true,
+    "description": "Fields to configure Call To Action prompts.",
+    "show_in_rest": 0,
+    "show_in_graphql": 1,
+    "graphql_field_name": "ctaOptions",
+    "map_graphql_types_from_location_rules": 0,
+    "graphql_types": "",
+    "modified": 1692902088
+}

--- a/wp-content/themes/the-world/acf-json/group_64e7874e3237c.json
+++ b/wp-content/themes/the-world/acf-json/group_64e7874e3237c.json
@@ -1,0 +1,52 @@
+{
+    "key": "group_64e7874e3237c",
+    "title": "CTA Settings",
+    "fields": [
+        {
+            "key": "field_64e78750bcaa9",
+            "label": "Cookie Lifespan",
+            "name": "cookie_lifespan",
+            "aria-label": "",
+            "type": "number",
+            "instructions": "Dissed messages use cookies to determine the next time it should be shown to a user. Set the number of minutes the cookie should expire. Default is '0' which expires when the user closes the browser window or tab.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "min": "",
+            "max": "",
+            "placeholder": 0,
+            "step": "",
+            "prepend": "",
+            "append": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "call_to_action"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "side",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "field",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "show_in_graphql": 1,
+    "graphql_field_name": "ctaSettings",
+    "map_graphql_types_from_location_rules": 0,
+    "graphql_types": "",
+    "modified": 1692895702
+}

--- a/wp-content/themes/the-world/acf-json/group_64e788ab4e23b.json
+++ b/wp-content/themes/the-world/acf-json/group_64e788ab4e23b.json
@@ -1,0 +1,115 @@
+{
+    "key": "group_64e788ab4e23b",
+    "title": "CTA Targeting",
+    "fields": [
+        {
+            "key": "field_64e788ad098a1",
+            "label": "Categories",
+            "name": "target_categories",
+            "aria-label": "",
+            "type": "taxonomy",
+            "instructions": "Select which categories this CTA should appear on. CTA will be shown on the terms' landing pages, and content tagged by these terms.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "taxonomy": "category",
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "field_type": "multi_select",
+            "allow_null": 0,
+            "bidirectional": 0,
+            "multiple": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_64e789ff54b78",
+            "label": "Programs",
+            "name": "target_programs",
+            "aria-label": "",
+            "type": "taxonomy",
+            "instructions": "Select which programs this CTA should appear on. CTA will be shown on the terms' landing pages, and content tagged by these terms.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "taxonomy": "program",
+            "add_term": 0,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "field_type": "multi_select",
+            "allow_null": 0,
+            "bidirectional": 0,
+            "multiple": 0,
+            "bidirectional_target": []
+        },
+        {
+            "key": "field_64e79b74aa8d2",
+            "label": "Content",
+            "name": "target_content",
+            "aria-label": "",
+            "type": "relationship",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "post_type": [
+                "post",
+                "episode"
+            ],
+            "post_status": [
+                "publish"
+            ],
+            "taxonomy": "",
+            "filters": [
+                "search",
+                "post_type"
+            ],
+            "return_format": "id",
+            "min": "",
+            "max": "",
+            "elements": "",
+            "bidirectional": 0,
+            "bidirectional_target": []
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "call_to_action"
+            }
+        ]
+    ],
+    "menu_order": 10,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "field",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "Fields for targeting CTA's to content, either directly or by taxonomy.",
+    "show_in_rest": 0,
+    "show_in_graphql": 1,
+    "graphql_field_name": "ctaTargeting",
+    "map_graphql_types_from_location_rules": 0,
+    "graphql_types": "",
+    "modified": 1692902932
+}


### PR DESCRIPTION
Closes #10 

- add call_to_action post type
- add cta_region post type
- add cta_region_type taxonomy
- config acf fields for call_to_action posts
- config acf fields for cta_region posts

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Log in as an admin to http://the-world-wp.lndo.site/wp-admin.

> ...then...

- [x] Ensure you see **Call To Actions** and **CTA Regions** in the menu. If you don't, go to Plugins and Deactivate the _TW Call To Actions (CTA's)_ plugin. Also try viewing your user's capabilities and refreshing a couple times.
- [x] Go to **Call To Actions** and click **Add New**.
- [x] Set up any type of CTA you want, ensuring the relevant fields are provided for the type you are creating. Publish it when ready. (Do multiple if you like.)
- [x] Go to **CTA Regions**. and click **Add New**
- [x] Title the region "Site Banner" and add your Call To Action posts to it.
- [x] Set the _CTA Region Type_ to "Site".
- [x] Add a helpful description for the region in the _Excerpt_ field.
- [x] Publish CTA Region.
- [x] Go to GraphQL IDE and enter this query:
```
query getCtaRegions {
  callToActions(first: 10) {
    nodes {
      ... CtaProps
    }
  }
  ctaRegion(id: "site-banner", idType: SLUG) {
    ... CtaRegionProps
  }
  ctaRegionType(id: "site", idType: SLUG) {
    id
    name
    ctaRegions {
      nodes {
        ... CtaRegionProps
      }
    }
  }
}

fragment CtaRegionProps on CtaRegion {
  id
  title
  slug
  ctaRegionContent {
    callToActions {
      ... CtaProps
    }
  }
}

fragment CtaProps on CallToAction {
    ctaOptions {
      ctaType
      content {
        heading
        message
      }
      actions {
        actionButtonLabel
        actionButtonUrl
        dismissButtonLabel
      }
      optInSettings {
        optInText
      }
      newsletterSettings {
        newsletter {
          ... on Newsletter {
            id
            title
            newsletterOptions {
              buttonLabel
              listId
              optInText
            }
          }
        }
      }
    }
    ctaSettings {
      cookieLifespan
    }
    ctaTargeting {
      targetCategories {
        id
        name
      }
      targetPrograms {
        id
        name
      }
      targetContent {
        ... on Post {
          id
          title
        }
        ... on Episode {
          id
          title
        }
      }
    }
}
```
- [x] Run the query.
- [x] Ensure the data for CTA's you added is retrieved. The query should first list the first 10 CTA's, then the CTA's in the `site-banner` region, then the regions tagged as the `site` type and it's CTA's .
- [x] Edit a term in each major taxonomy other than _CTA Region Types_ and ensure the **Landing Page** and **Taxonomy Images** field groups are shown.