### PR TITLE
103: Add Primary Term fields to post types for hierarchical taxonomies

### DIFF
--- a/wp-config-development.php
+++ b/wp-config-development.php
@@ -16,3 +16,5 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 // Configure S3 Uploads.
 define( 'S3_UPLOADS_BUCKET', 'media-pri-dev/s3fs-public' );
 define( 'S3_UPLOADS_REGION', 'us-east-1' );
+
+define ( 'GRAPHQL_DEBUG', true );

--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -23,6 +23,7 @@ define(
 		'tw-disable-yoast-indexables/tw-disable-yoast-indexables.php',
 		'tw-endpoint-helper/tw-endpoint-helper.php',
 		'tw-episodes/tw-episodes.php',
+		'tw-graphql/tw-graphql.php',
 		'tw-import-post-types/tw-import-post-types.php', // This is the plugin that creates the custom post types for the import. Can be removed after the import is complete.
 		'tw-media/tw-media.php',
 		'tw-menus/tw-menus.php',

--- a/wp-content/plugins/tw-graphql/tw-graphql.php
+++ b/wp-content/plugins/tw-graphql/tw-graphql.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Plugin Name: TW GraphQL
+ * Description: Customize WP GraphQL API
+ *
+ * @package tw_graphql
+ */
+
+ if (!defined('ABSPATH')) {
+    exit();
+}
+
+use WPGraphQL\AppContext;
+use WPGraphQL\Model\Term;
+
+ /**
+ * Register GraphQL fields.
+ */
+add_action(
+	'graphql_register_types',
+	function () {
+		$customposttype_graphql_single_name = 'Post'; // Replace this with your custom post type single name in PascalCase.
+
+		// Registering the 'categorySlug' argument in the 'where' clause.
+		// Feel free to change the name 'categorySlug' to something that suits your requirements.
+		register_graphql_field(
+			'RootQueryTo' . $customposttype_graphql_single_name . 'ConnectionWhereArgs',
+			'programNotIn',
+			array(
+				'type'        => array( 'list_of' => 'ID' ), // To accept multiple strings.
+				'description' => __( 'Filter by post objects that do not have the specified programs.', 'text_domain' ),
+			)
+		);
+
+		// Add primary term field to post types for hierachical taxonomies.
+        $post_types = \WPGraphQL::get_allowed_post_types();
+        $taxonomies = \WPGraphQL::get_allowed_taxonomies();
+
+		if (!empty($post_types) && is_array($post_types)) {
+			foreach ($post_types as $post_type) {
+				$post_type_object = get_post_type_object($post_type);
+
+				if (isset($post_type_object->graphql_single_name)) {
+					// Loop each taxonomy to register on the edge if a category is the primary one.
+                    $taxonomiesPostObj = get_object_taxonomies($post_type, 'objects');
+
+                    $postNameKey = wp_gql_seo_get_field_key($post_type_object->graphql_single_name);
+
+                    foreach ($taxonomiesPostObj as $tax) {
+						$postTypeUsesTaxonomy = in_array($tax->name)
+                        if (isset($tax->hierarchical) && $tax->hierarchical && isset($tax->graphql_single_name)) {
+							$taxNameKey = wp_gql_seo_get_field_key($tax->graphql_single_name);
+
+                            register_graphql_field(ucfirst($postNameKey), 'primary' . ucfirst($tax->graphql_single_name), [
+                                'type' => ucfirst($taxNameKey),
+                                'description' => __('The Yoast SEO Primary ' . $tax->name, 'text_domain'),
+                                'resolve' => function ($item, array $args, AppContext $context) use ($tax, $taxNameKey) {
+                                    $postId = $item->ID;
+
+                                    $wpseo_primary_term = new WPSEO_Primary_Term($tax->name, $postId);
+                                    $primaryTaxId = $wpseo_primary_term->get_primary_term();
+
+                                    return $context->get_loader('term')->load_deferred(absint($primaryTaxId));
+                                },
+                            ]);
+                        }
+                    }
+				};
+			}
+		}
+	}
+);
+
+/**
+ * Modify GraphQL queries too support registered fields.
+ */
+add_filter(
+	'graphql_post_object_connection_query_args',
+	function ( $query_args, $source, $args, $context, $info ) {
+
+		$excluded_program_ids = $args['where']['programNotIn'];
+
+		if ( isset( $excluded_program_ids ) ) {
+			// If the 'programNotIn' argument is provided, we add it to the tax_query.
+			// For more details, refer to the WP_Query class documentation at https://developer.wordpress.org/reference/classes/wp_query/.
+
+			// Decode hashed ids.
+			$ids = array_map(
+				function( $id ) {
+					if ( ! is_numeric( $id ) ) {
+						// Decode hashed id.
+						$decoded_id  = base64_decode( $id );
+						list( , $id) = explode( ':', $decoded_id );
+					}
+					return $id;
+				},
+				$excluded_program_ids
+			);
+
+			$query_args['tax_query'] = array(
+				array(
+					'taxonomy' => 'program',
+					'field'    => 'term_id',
+					'terms'    => $ids,
+					'operator' => 'NOT IN',
+				),
+			);
+		}
+
+		return $query_args;
+	},
+	10,
+	5
+);

--- a/wp-content/plugins/tw-graphql/tw-graphql.php
+++ b/wp-content/plugins/tw-graphql/tw-graphql.php
@@ -37,18 +37,22 @@ add_action(
         $taxonomies = \WPGraphQL::get_allowed_taxonomies();
 
 		if (!empty($post_types) && is_array($post_types)) {
+			// Loop through each post type...
 			foreach ($post_types as $post_type) {
 				$post_type_object = get_post_type_object($post_type);
 
+				// Only add field to post types that are configured for graphql.
 				if (isset($post_type_object->graphql_single_name)) {
-					// Loop each taxonomy to register on the edge if a category is the primary one.
                     $taxonomiesPostObj = get_object_taxonomies($post_type, 'objects');
-
                     $postNameKey = wp_gql_seo_get_field_key($post_type_object->graphql_single_name);
 
+					// Loop through each taxomony...
                     foreach ($taxonomiesPostObj as $tax) {
-						$postTypeUsesTaxonomy = in_array($tax->name)
-                        if (isset($tax->hierarchical) && $tax->hierarchical && isset($tax->graphql_single_name)) {
+						$isHierarchicalTaxonomy = isset($tax->hierarchical) && $tax->hierarchical;
+						$postTypeUsesTaxonomy = in_array($post_type_object->name, $tax->object_type);
+
+						// Only add field for taxonomies that are configured for graphql, are hierachical, and are used by the post type.
+                        if ($isHierarchicalTaxonomy && $postTypeUsesTaxonomy && isset($tax->graphql_single_name)) {
 							$taxNameKey = wp_gql_seo_get_field_key($tax->graphql_single_name);
 
                             register_graphql_field(ucfirst($postNameKey), 'primary' . ucfirst($tax->graphql_single_name), [


### PR DESCRIPTION
Closes #103 

- add tw-graphql plugin to own graphql api modifications
- add primary term fields to post types for hierarchical taxonomies
- move `programNotIn` filter arg registration to tw-graphql plugin

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Go to http://the-world-wp.lndo.site/.

> ...then...

- [x] Go to GraphQL IDE
- [x] Enter this query:
```
query GetPosts {
  posts {
    nodes {
      id
      title
      slug
      primaryCategory {
        id
        name
      }
    }
  }
}
```
- [x] Ensure running the query returns the expected `primaryCategory` data and doesn't error. Field should be `null` if no primary category was selected.

> Currently the only hierarchical taxonomy we use is categories. If we ever add a hierarchical taxonomy in the future, a primary term field for that taxonomy will be added to post types using the taxonomy.