### PR TITLE
feat(theworld): enable spotify embeds

### DIFF
--- a/wp-content/themes/the-world/css/block-editor.css
+++ b/wp-content/themes/the-world/css/block-editor.css
@@ -2,8 +2,8 @@
 @media (min-width: 782px) {
   .is-sidebar-opened
     .block-editor-block-list__layout.is-root-container
-    > .block-editor-block-list__block.wp-block:is(.alignfull) {
-    width: calc(100vw - 280px);
+    > .block-editor-block-list__block.wp-block:is(.alignfull, .alignwide) {
+    width: calc(var(--_full-width, 100vw) - 280px);
   }
 }
 

--- a/wp-content/themes/the-world/css/editor.css
+++ b/wp-content/themes/the-world/css/editor.css
@@ -23,23 +23,24 @@ body {
 }
 
 .block-editor-block-list__layout.is-root-container
-  > .wp-block:where(.alignwide, .alignfull):not(.alignleft, .alignright) {
+  > .wp-block:where(.alignwide, .alignfull) {
   position: relative;
   left: 50%;
   translate: -50% 0;
-  width: 100vw;
 }
-.block-editor-block-list__layout.is-root-container
-  > .wp-block:is(.alignwide):not(.alignleft, .alignright) {
+.block-editor-block-list__layout.is-root-container > .wp-block:is(.alignwide) {
   max-width: var(--_editor--content--width);
 }
 .block-editor-block-list__layout.is-root-container
   > .wp-block:is(.alignleft, .alignright) {
   float: none;
-  margin-inline: 0 !important;
+  width: 100%;
+  max-width: calc(100% - (var(--_editor--content--gutter) * 2));
+  margin-inline: auto !important;
 }
 .block-editor-block-list__layout.is-root-container
   > .wp-block:is(.aligncenter) {
+  width: 100%;
   max-width: calc(100% - (var(--_editor--content--gutter) * 2));
   text-align: left;
 }
@@ -95,15 +96,20 @@ body {
 }
 
 .block-editor-block-list__layout.is-root-container
-  > :is(
-    .wp-block-embed[data-title="Twitter"]:not(.alignleft, .alignright),
-    .wp-block-embed[data-title="Twitter"]:is(.alignwide, .alignfull)
+  > .wp-block-embed[data-title="Twitter"]:is(.alignwide, .alignfull):not(
+    .alignleft,
+    .alignright
   ) {
   left: unset;
   translate: unset;
   width: auto;
   max-width: 550px;
   margin-inline: auto;
+}
+
+.block-editor-block-list__layout.is-root-container
+  > .wp-block-embed[data-title="Spotify"]:is(.alignwide, .alignfull) {
+  --_full-width: calc(100vw - var(--_editor--content--gutter));
 }
 
 .block-editor-block-list__block.wp-block-separator {

--- a/wp-content/themes/the-world/js/blockembed.js
+++ b/wp-content/themes/the-world/js/blockembed.js
@@ -11,7 +11,13 @@ wp.domReady(function () {
   }
 
   // Allow only certain embed variants.
-  const allowedEmbedBlocks = ["twitter", "youtube", "vimeo", "datawrapper"];
+  const allowedEmbedBlocks = [
+    "datawrapper",
+    "spotify",
+    "twitter",
+    "youtube",
+    "vimeo",
+  ];
 
   wp.blocks.getBlockVariations("core/embed").forEach(function (blockVariation) {
     if (-1 === allowedEmbedBlocks.indexOf(blockVariation.name)) {
@@ -43,6 +49,30 @@ wp.hooks.addFilter(
             anchor: false,
             spacing: {},
           },
+        };
+
+      case "core/embed":
+        return {
+          ...settings,
+          variations: settings.variations?.map((variation) => {
+            const { name } = variation;
+
+            switch (name) {
+              // Disable responsive option for Spotify embeds.
+              // Doesn't play well with responsive layouts inside the Spotify iframe.
+              case "spotify":
+                return {
+                  ...variation,
+                  attributes: {
+                    ...variation.attributes,
+                    allowResponsive: false,
+                    responsive: false,
+                  },
+                };
+              default:
+                return variation;
+            }
+          }),
         };
 
       default:


### PR DESCRIPTION
- enables Spotify embed blocks
- update alignment styles to better support Spotify embeds

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Log into http://the-world-wp.lndo.site/wp-admin/

> ...then...

- [x] Edit any story.
- [x] Add a Spotify embed. (Copy from Spotify: _Context Menu > Share > Copy Album/Song Link_)
- [x] Ensure the embed loads and looks good at each alignment position.
- [x] Save changes to story.
- [x] Start PR review of PRX/theworld.org#436
- [x] View published story (should take you you local front-end.)
- [x] Ensure Spotify embed loads and lays out as expected on front-end.
