### PR TITLE
Use category body field as description only when description is empty

### DIFF
--- a/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
+++ b/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
@@ -244,7 +244,7 @@ function pri_fgd2wp_pre_insert_taxonomy_term( $custom_field_values, $new_term_id
 		case 'category-body':
 			if ( $custom_field_values && ! empty( $custom_field_values[0] ) ) {
 				$cat_description = get_term_field( 'description', $new_term_id, 'category', 'raw' );
-				if ( ! $cat_description && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
+				if ( empty( trim( $cat_description ) ) && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
 					$args['description'] = $custom_field_values[0]['field_body_value'];
 					wp_update_term( $new_term_id, 'category', $args );
 				}

--- a/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
+++ b/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
@@ -244,7 +244,8 @@ function pri_fgd2wp_pre_insert_taxonomy_term( $custom_field_values, $new_term_id
 		case 'category-body':
 			if ( $custom_field_values && ! empty( $custom_field_values[0] ) ) {
 				$cat_description = get_term_field( 'description', $new_term_id, 'category', 'raw' );
-				if ( is_string( $cat_description ) && empty( trim( $cat_description ) ) && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
+				$cat_description_is_valid = is_string( $cat_description ) && ! empty( trim( $cat_description ) );
+				if ( ! $cat_description_is_valid && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
 					$args['description'] = $custom_field_values[0]['field_body_value'];
 					wp_update_term( $new_term_id, 'category', $args );
 				}

--- a/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
+++ b/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
@@ -243,8 +243,12 @@ function pri_fgd2wp_pre_insert_taxonomy_term( $custom_field_values, $new_term_id
 	switch ( $custom_field_name ) {
 		case 'category-body':
 			if ( $custom_field_values && ! empty( $custom_field_values[0] ) ) {
-				$args['description'] = get_term_field( 'description', $new_term_id, 'category', 'raw' ) . ' ' . $custom_field_values[0]['field_body_value'];
-				wp_update_term( $new_term_id, 'category', $args );
+				$cat_description = get_term_field( 'description', $new_term_id, 'category', 'raw' );
+				if ( ! $cat_description && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
+					$args['description'] = $custom_field_values[0]['field_body_value'];
+					wp_update_term( $new_term_id, 'category', $args );
+				}
+
 				$custom_field_values = array();
 			}
 			break;

--- a/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
+++ b/wp-content/plugins/pri-migration-helper/migration/taxonomy_filters/taxonomy-category.php
@@ -244,7 +244,7 @@ function pri_fgd2wp_pre_insert_taxonomy_term( $custom_field_values, $new_term_id
 		case 'category-body':
 			if ( $custom_field_values && ! empty( $custom_field_values[0] ) ) {
 				$cat_description = get_term_field( 'description', $new_term_id, 'category', 'raw' );
-				if ( empty( trim( $cat_description ) ) && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
+				if ( is_string( $cat_description ) && empty( trim( $cat_description ) ) && ! empty( $custom_field_values[0]['field_body_value'] ) ) {
 					$args['description'] = $custom_field_values[0]['field_body_value'];
 					wp_update_term( $new_term_id, 'category', $args );
 				}


### PR DESCRIPTION
- Change the code to use Drupal Category Body field for those categories where the description is empty.
