### PR TITLE
Include fix image size attributes in the normal import process

### DIFF
--- a/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
+++ b/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
@@ -601,8 +601,31 @@ function pmh_add_external_media_without_import( $url, $attributes = array(), $op
 		// Image dimension.
 		if ( wp_attachment_is( 'image', $attachment_id ) ) {
 
-			$attachment_metadata['width']  = $width ? $width : 1024;
-			$attachment_metadata['height'] = $height ? $height : 1024;
+			// Set width and height to 0.
+			$attachment_metadata['width']  = $width;
+			$attachment_metadata['height'] = $height;
+
+			// If one of the dimension is missing.
+			if ( ! $width || ! $height ) {
+
+				// Get image size.
+				$image_sizes = f_pmh_get_drupal_image_sizes( $fid );
+
+				// If image sizes is found and isset.
+				if (
+					$image_sizes
+					&&
+					isset( $image_sizes['width'] )
+					&&
+					isset( $image_sizes['height'] )
+				) {
+
+					// Set width and height.
+					$attachment_metadata['width']  = $image_sizes['width'];
+					$attachment_metadata['height'] = $image_sizes['height'];
+				}
+			}
+
 			$attachment_metadata['sizes']  = array( 'full' => $attachment_metadata );
 		}
 

--- a/wp-content/plugins/pri-migration-helper/migration/migration.php
+++ b/wp-content/plugins/pri-migration-helper/migration/migration.php
@@ -509,4 +509,5 @@ function pri_post_import_media_fix() {
 	// Run media fix.
 	$o_media_fix_cli->image_fix( $a_media_fix_arguments );
 }
-add_action( 'fgd2wp_post_import', 'pri_post_import_media_fix', 100 );
+// Disable this hook for now as the code was included in the normal import process. And we don't need to run it after migration.
+// add_action( 'fgd2wp_post_import', 'pri_post_import_media_fix', 100 );


### PR DESCRIPTION
This PR includes the image size fix as part of the normal import and disable the process which does the same at the end of the import to avoid trying to fix the size twice.
