### PR TITLE
Adds admin sidebar link to TW Program page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,41 +1,50 @@
 {
-	"cSpell.words": [
-		"ABSPATH",
-		"DOCROOT",
-		"jetpack",
-		"Lando",
-		"multidev",
-		"multidevs",
-		"newspack",
-		"pullquote",
-		"SITEURL",
-		"ssot",
-		"uncategorized",
-		"untrailingslashit",
-		"wpcfm",
-		"WPINC",
-		"WPMU"
-	],
-	"cSpell.ignorePaths": [
-		"package-lock.json",
-		"node_modules",
-		"vscode-extension",
-		".git/objects",
-		".vscode",
-		".vscode-insiders",
-		"wp-content/plugins",
-		"vendor"
-	],
-	"phpcs.composerJsonPath": "composer.json",
-	"phpcs.executablePath": "./vendor/bin/phpcs",
-	"phpcs.standard": "WordPress",
-	"phpSniffer.autoDetect": true,
-	"phpSniffer.standard": "WordPress",
-	"editorconfig.generateAuto": false,
-	"editor.formatOnSave": true,
-	"[php]": {
-		"editor.defaultFormatter": "wongjn.php-sniffer"
-	},
+  "cSpell.words": [
+    "ABSPATH",
+    "blockembed",
+    "dashicons",
+    "DOCROOT",
+    "httponly",
+    "jetpack",
+    "Lando",
+    "multidev",
+    "multidevs",
+    "newspack",
+    "pagename",
+    "postname",
+    "pullquote",
+    "shortcode",
+    "SITEURL",
+    "ssot",
+    "theworld",
+    "uncategorized",
+    "untrailingslashit",
+    "wlwmanifest",
+    "wpcfm",
+    "WPINC",
+    "WPMU",
+    "wpseo"
+  ],
+  "cSpell.ignorePaths": [
+    "package-lock.json",
+    "node_modules",
+    "vscode-extension",
+    ".git/objects",
+    ".vscode",
+    ".vscode-insiders",
+    "wp-content/plugins",
+    "vendor"
+  ],
+  "phpcs.composerJsonPath": "composer.json",
+  "phpcs.executablePath": "./vendor/bin/phpcs",
+  "phpcs.standard": "WordPress",
+  "phpSniffer.autoDetect": true,
+  "phpSniffer.standard": "WordPress",
+  "editorconfig.generateAuto": false,
+  "editor.formatOnSave": true,
+  "[php]": {
+    "editor.defaultFormatter": "wongjn.php-sniffer"
+  },
   "[html]": {
     "editor.defaultFormatter": "co6x0.vscode-wp-block-html"
   },
@@ -45,7 +54,7 @@
   "editor.quickSuggestions": {
     "strings": "on"
   },
-	"editor.defaultFormatter": null,
+  "editor.defaultFormatter": null,
   "eslint.format.enable": true,
   "[javascriptreact]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -263,8 +263,13 @@ add_filter( 'should_load_remote_block_patterns', '__return_false' );
 remove_action( 'wp_head', 'wlwmanifest_link' );
 
 if ( ! function_exists( 'tw_custom_menu_link' ) ) :
+	/**
+	 * Add .
+	 *
+	 * @uses add_menu_page() Add links to the menu.
+	 */
 	function tw_custom_menu_link() {
-		add_menu_page('tw_edit_hompage_link', 'The World Homepage', 'publish_posts', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
+		add_menu_page('tw_edit_homepage_link', 'The World Homepage', 'publish_posts', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
 	}
 endif;
 add_action('admin_menu', 'tw_custom_menu_link');

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -264,7 +264,7 @@ remove_action( 'wp_head', 'wlwmanifest_link' );
 
 if ( ! function_exists( 'tw_custom_menu_link' ) ) :
 	function tw_custom_menu_link() {
-		add_menu_page('my_custom_link_1', 'The World Homepage', 'read', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
+		add_menu_page('tw_edit_hompage_link', 'The World Homepage', 'publish_posts', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
 	}
 endif;
 add_action('admin_menu', 'tw_custom_menu_link');

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -262,7 +262,9 @@ add_filter( 'should_load_remote_block_patterns', '__return_false' );
 // Remove Windows Live Writer manifest link.
 remove_action( 'wp_head', 'wlwmanifest_link' );
 
-add_action('admin_menu', 'add_custom_menu_link');
-function add_custom_menu_link() {
-	add_menu_page('my_custom_link_1', 'The World Homepage', 'read', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
-}
+if ( ! function_exists( 'tw_custom_menu_link' ) ) :
+	function tw_custom_menu_link() {
+		add_menu_page('my_custom_link_1', 'The World Homepage', 'read', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
+	}
+endif;
+add_action('admin_menu', 'tw_custom_menu_link');

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -262,14 +262,14 @@ add_filter( 'should_load_remote_block_patterns', '__return_false' );
 // Remove Windows Live Writer manifest link.
 remove_action( 'wp_head', 'wlwmanifest_link' );
 
-if ( ! function_exists( 'tw_custom_menu_link' ) ) :
+if ( ! function_exists( 'tw_add_edit_homepage_menu_link' ) ) :
 	/**
 	 * Add convenient link for editors to edit homepage.
 	 *
 	 * @uses add_menu_page() Add links to the menu.
 	 */
-	function tw_custom_menu_link() {
+	function tw_add_edit_homepage_menu_link() {
 		add_menu_page('tw_edit_homepage_link', 'The World Homepage', 'publish_posts', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
 	}
 endif;
-add_action('admin_menu', 'tw_custom_menu_link');
+add_action('admin_menu', 'tw_add_edit_homepage_menu_link');

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -264,7 +264,7 @@ remove_action( 'wp_head', 'wlwmanifest_link' );
 
 if ( ! function_exists( 'tw_custom_menu_link' ) ) :
 	/**
-	 * Add .
+	 * Add convenient link for editors to edit homepage.
 	 *
 	 * @uses add_menu_page() Add links to the menu.
 	 */

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -261,3 +261,8 @@ add_filter( 'should_load_remote_block_patterns', '__return_false' );
 
 // Remove Windows Live Writer manifest link.
 remove_action( 'wp_head', 'wlwmanifest_link' );
+
+add_action('admin_menu', 'add_custom_menu_link');
+function add_custom_menu_link() {
+	add_menu_page('my_custom_link_1', 'The World Homepage', 'read', "/wp-admin/term.php?taxonomy=program&tag_ID=2&post_type=post", '', 'dashicons-admin-site-alt3', 8);
+}


### PR DESCRIPTION
- Adds admin sidebar link to TW Program page for easier access to curate homepage

## To Review

- [ ] Checkout Branch.
- [ ] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [ ] Go to http://the-world-wp.lndo.site/.

> ...then...

- [ ] go to http://the-world-wp.lndo.site/wp-admin and confirm there's a `The World Homepage` link
- [ ] click it, and ensure you are taken to the edit screen for The World's Program term.
 