### PR TITLE
Redirects tables and tool to update single elements

### DIFF
--- a/wp-content/plugins/pri-migration-helper/README.md
+++ b/wp-content/plugins/pri-migration-helper/README.md
@@ -20,3 +20,12 @@ Used to test the code used to replace img tags by image blocks in a single post.
 `wp tw-fix post_tags_fix_duplicate [start_page_number post_per_page]`
 Command to loop through all post_tags, check each term if it is duplicated in other custom taxonomies.
 If it is duplicated, add posts related to the post_tag to the custom taxonomy term.
+### Redirect table
+`wp tw-fix repair_wp_fg_redirect_tables [page_number]`
+Command to create redirects for all taxonomies and post types migrated.
+`wp tw-fix repair_wp_fg_redirect_table [obect_type, object_name, page_number]`
+Command to create redirects for specific taxonomies or post types migrated.
+* Example: `wp tw-fix repair_wp_fg_redirect_table taxonomy category`
+### Redirect table
+`wp tw-fix update_url_alias_table [last_id, limit]`
+ Command to add all the aliases stored in url_alias Drupal table. Last ID imported will be stored to continue from there. If migration from scratch is needed the last_id parameter must be set as 1.

--- a/wp-content/plugins/pri-migration-helper/admin/parts/selective-fix.php
+++ b/wp-content/plugins/pri-migration-helper/admin/parts/selective-fix.php
@@ -1,0 +1,67 @@
+<?php
+if ( isset( $_POST['pmh-selective-fix'] ) && '1' === $_POST['pmh-selective-fix'] ) {
+
+	// Save content types default.
+	$set_selective_fix_content_types = array();
+
+	// Save post node ids.
+	if ( isset( $_POST['pmh-post-fix-ids'] ) ) {
+
+		update_option( 'tw_get_nodes_story_target_ids', sanitize_textarea_field( $_POST['pmh-post-fix-ids'] ) );
+
+		if (  ! empty( $_POST['pmh-post-fix-ids'] ) ) {
+
+			$set_selective_fix_content_types[] = 'story';
+		}
+	}
+
+	// Save episode node ids.
+	if ( isset( $_POST['pmh-episode-fix-ids'] ) ) {
+
+		update_option( 'tw_get_nodes_episode_target_ids', sanitize_textarea_field( $_POST['pmh-episode-fix-ids'] ) );
+
+		if (  ! empty( $_POST['pmh-episode-fix-ids'] ) ) {
+
+			$set_selective_fix_content_types[] = 'episode';
+		}
+	}
+
+	// Save content types.
+	update_option( 'tw_selective_fix_content_types', $set_selective_fix_content_types );
+}
+
+// Get node ids.
+$post_node_ids = get_option( 'tw_get_nodes_story_target_ids' );
+$episode_node_ids = get_option( 'tw_get_nodes_episode_target_ids' );
+
+// Current selected content types.
+$selective_fix_content_types = get_option( 'tw_selective_fix_content_types', array() );
+$selective_fix_content_types_string = $selective_fix_content_types ? implode( ', ', $selective_fix_content_types ) : 'None';
+?>
+<p>This tool will scope the import process to selected IDs only.</p>
+<p>Current selected content types: <?php echo $selective_fix_content_types_string; ?></p>
+
+<form method="POST">
+	<table id="pmh-episode-fix" class="form-table">
+		<tbody>
+			<tr>
+				<th scope="row"><label for="pmh-post-fix-ids"><?php esc_html_e( 'Story nid', 'pmh' ); ?></label></th>
+				<td>
+					<textarea name="pmh-post-fix-ids" id="pmh-post-fix-ids" cols="80" rows="5"><?php echo $post_node_ids; ?></textarea>
+					<p><i>Separated by comma (,). Leave empty to process all.</i></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="pmh-episode-fix-ids"><?php esc_html_e( 'Episode nid', 'pmh' ); ?></label></th>
+				<td>
+					<textarea name="pmh-episode-fix-ids" id="pmh-episode-fix-ids" cols="80" rows="5"><?php echo $episode_node_ids; ?></textarea>
+					<p><i>Separated by comma (,). Leave empty to process all.</i></p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<p>
+		<input type="hidden" name="pmh-selective-fix" value="1">
+		<input type="submit" class="button button-primary" value="Save Settings">
+	</p>
+</form>

--- a/wp-content/plugins/pri-migration-helper/cli/cli.php
+++ b/wp-content/plugins/pri-migration-helper/cli/cli.php
@@ -16,7 +16,7 @@
  * 9. repair_wp_fg_redirect_tables [page_number]
  * 10. repair_wp_fg_redirect_table [obect_type, object_name, page_number]
  * Example: repair_wp_fg_redirect_table taxonomy category
- * 11. _image_captions [wp_image_id]
+ * 11. update_url_alias_table [last_id, limit]
  */
 
 // Add 'tw-media-fix-all' command to wp-cli.

--- a/wp-content/plugins/pri-migration-helper/cli/cli.php
+++ b/wp-content/plugins/pri-migration-helper/cli/cli.php
@@ -13,6 +13,10 @@
  *    Both are optional. If not provided, it will start from the beginning by 100 per process.
  * 8. _image_captions [wp_image_id]
  *    If targetting a single image, use this command instead.
+ * 9. repair_wp_fg_redirect_tables [page_number]
+ * 10. repair_wp_fg_redirect_table [obect_type, object_name, page_number]
+ * Example: repair_wp_fg_redirect_table taxonomy category
+ * 11. _image_captions [wp_image_id]
  */
 
 // Add 'tw-media-fix-all' command to wp-cli.

--- a/wp-content/plugins/pri-migration-helper/cli/includes/class-pmh-worker.php
+++ b/wp-content/plugins/pri-migration-helper/cli/includes/class-pmh-worker.php
@@ -1147,7 +1147,7 @@ class PMH_Worker {
 	 * Be sure to already have table wp_migrated_legacy_url_alias created.
 	 *
 	 * @param array $args
-	 *              $args[1] : Start from id. Use 0 to start from the last id in the option. Use 1 to start from the first id.
+	 *              $args[1] : Start from id. Use 0 or empty to start from the last id in the option. Use 1 to start from the first id.
 	 *              $args[2] : Limit.
 	 *
 	 * @return void

--- a/wp-content/plugins/pri-migration-helper/migration/migration.php
+++ b/wp-content/plugins/pri-migration-helper/migration/migration.php
@@ -509,5 +509,63 @@ function pri_post_import_media_fix() {
 	// Run media fix.
 	$o_media_fix_cli->image_fix( $a_media_fix_arguments );
 }
-// Disable this hook for now as the code was included in the normal import process. And we don't need to run it after migration.
 // add_action( 'fgd2wp_post_import', 'pri_post_import_media_fix', 100 );
+
+/**
+ * Modify extra conditions for getting nodes.
+ *
+ * @param string $extra_conditions Extra conditions.
+ * @param string $content_type Post type.
+ * @param string $entity_type Entity type.
+ *
+ * @return string
+ */
+function pri_migration_tw_get_nodes_add_extra_conditions( $extra_conditions, $content_type, $entity_type ) {
+
+	// Content types.
+	$selective_fix_content_types = get_option( 'tw_selective_fix_content_types', array() );
+
+	// Add extra conditions if content type matches.
+	if ( in_array( $content_type, $selective_fix_content_types, true ) ) {
+
+		// Get node ids.
+		$node_ids = get_option( 'tw_get_nodes_' . $content_type . '_target_ids' );
+
+		// If node ids exist.
+		if ( $node_ids ) {
+
+			// Add extra conditions.
+			$extra_conditions = ' AND ';
+			$extra_conditions .= "n.nid IN ($node_ids)";
+		}
+	}
+
+	return $extra_conditions;
+}
+add_filter( 'tw_get_nodes_add_extra_conditions', 'pri_migration_tw_get_nodes_add_extra_conditions', 10, 3 );
+
+/**
+ * Add how many nodes to process when extra conditions are added.
+ */
+function pri_migration_tw_how_many_nodes_to_import( $how_many_nodes_to_import, $content_type ) {
+
+	// Content types.
+	$selective_fix_content_types = get_option( 'tw_selective_fix_content_types', array() );
+
+	// Add extra conditions if content type matches.
+	if ( in_array( $content_type, $selective_fix_content_types, true ) ) {
+
+		// Get node ids.
+		$node_ids = get_option( 'tw_get_nodes_' . $content_type . '_target_ids' );
+
+		// If node ids exist.
+		if ( $node_ids ) {
+
+			// Add extra conditions.
+			$how_many_nodes_to_import = count( explode( ',', $node_ids ) );
+		}
+	}
+
+	return $how_many_nodes_to_import;
+}
+add_filter( 'tw_how_many_nodes_to_import', 'pri_migration_tw_how_many_nodes_to_import', 10, 2 );


### PR DESCRIPTION
- WP CLI command `repair_wp_fg_redirect_tables`  to create relationship between Drupal node and WP ID.
- WP CLI command `update_url_alias_table`  to create all the aliases added to Drupal url alias table.
- WP Admin UI that will allow us to setup specific Drupal IDs to be migrated, this will be useful in case we need to test something.
WP CLI commands were added to the client documentation and also to the Migration Document.