### PR TITLE
Add symbolic links to enable environment writable folders

### DIFF
--- a/private/config/dev
+++ b/private/config/dev
@@ -1,0 +1,1 @@
+../../../files/private/config/dev

--- a/private/config/live
+++ b/private/config/live
@@ -1,0 +1,1 @@
+../../../files/private/config/live


### PR DESCRIPTION
In Pantheon all folders inside `code` are not writeable, so, we need symbolic links to `files` folder to make them writeable.
