### PR TITLE
Activate Patched S3 Upload plugin

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -14,6 +14,7 @@ define(
 		'disable-comments/disable-comments.php',
 		'genesis-custom-blocks/genesis-custom-blocks.php',
 		'PATCH-external-media-without-import/external-media-without-import.php',
+		'PATCH-s3-uploads/s3-uploads.php',
 		'microsoft-start/index.php',
 		'pwa/pwa.php',
 		'redirection/redirection.php',

--- a/wp-content/plugins/PATCH-s3-uploads/s3-uploads.php
+++ b/wp-content/plugins/PATCH-s3-uploads/s3-uploads.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
-Plugin Name: S3 Uploads
+Plugin Name: S3 Uploads (PATCHED)
 Description: Store uploads in S3
 Author: Human Made Limited
 Version: 3.0.3
 Author URI: https://hmn.md
 */
 
-// wp-content/plugins/s3-uploads/s3-uploads.php
+// wp-content/plugins/s3-uploads/s3-uploads.php.
 if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
-  // Require AWS Autoloader file.
- require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+	// Require AWS Autoloader file.
+	require_once __DIR__ . '/vendor/autoload.php';
 }
 
 require_once __DIR__ . '/inc/namespace.php';


### PR DESCRIPTION
- Uploads files to s3 bucket (the plugin was not in the global-plugins file and thusly not activated.

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Go to http://the-world-wp.lndo.site/.

> ...then...

- [x] Go to the media tab
- [x] upload a new file
- [x] confirm the File URL is pointing to `media-pri-dev.s3.amazonaws.com`
