### PR TITLE
Add download media to get its size if it does not exist in drupal

### DIFF
--- a/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
+++ b/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
@@ -615,14 +615,32 @@ function pmh_add_external_media_without_import( $url, $attributes = array(), $op
 				if (
 					$image_sizes
 					&&
-					isset( $image_sizes['width'] )
+					( isset( $image_sizes['width'] ) && $image_sizes['width'] )
 					&&
-					isset( $image_sizes['height'] )
+					( isset( $image_sizes['height'] ) && $image_sizes['height'] )
 				) {
 
 					// Set width and height.
 					$attachment_metadata['width']  = $image_sizes['width'];
 					$attachment_metadata['height'] = $image_sizes['height'];
+				} else {
+					// Get the attachment URL.
+					$s_attachment_url = wp_get_attachment_url( $attachment_id );
+					// Initialize media fix cli object.
+					$media_fix_cli = new PMH_Worker();
+
+					// Get the image dimensions.
+					$a_image_sizes = $media_fix_cli->clean_url_get_imagesize( $s_attachment_url );
+
+					// If the image dimensions are found.
+					if ( $a_image_sizes ) {
+
+						list( $i_width, $i_height ) = $a_image_sizes;
+
+						// Update the attachment metadata.
+						$attachment_metadata['width']  = $i_width;
+						$attachment_metadata['height'] = $i_height;
+					}
 				}
 			}
 

--- a/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
+++ b/wp-content/plugins/pri-migration-helper/migration/media_filters/media-global-filters.php
@@ -631,6 +631,7 @@ function pmh_add_external_media_without_import( $url, $attributes = array(), $op
 
 					// Get the image dimensions.
 					$a_image_sizes = $media_fix_cli->clean_url_get_imagesize( $s_attachment_url );
+					update_post_meta( $attachment_id, '_temp_import_image_size_from_download', $a_image_sizes );
 
 					// If the image dimensions are found.
 					if ( $a_image_sizes ) {
@@ -640,6 +641,14 @@ function pmh_add_external_media_without_import( $url, $attributes = array(), $op
 						// Update the attachment metadata.
 						$attachment_metadata['width']  = $i_width;
 						$attachment_metadata['height'] = $i_height;
+					} else {
+						// If width and height are still missing after a dowload set them with max wp size as default value.
+						if ( ! $attachment_metadata['width'] ) {
+							$attachment_metadata['width'] = 2560;
+						}
+						if ( ! $attachment_metadata['height'] ) {
+							$attachment_metadata['height'] = 2560;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- When images processed from Drupal does not have meta data, download the file and get the size from there.
- To avoid fatal errors, a default size as 2560px width and height was added in case the download file fails.
- New post meta `_temp_import_image_size_from_download` was added to store the sizes returned from the downloaded file in case we want to use as debug. This key was added to the list of metas to be removed.
