### PR TITLE
HOTFIX: configure wp environment type constant

### DIFF
--- a/wp-config-pantheon.php
+++ b/wp-config-pantheon.php
@@ -83,6 +83,7 @@ if ( getenv( 'WP_ENVIRONMENT_TYPE' ) === false ) {
 			break;
 		case 'test':
 			putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+			define( 'WP_ENVIRONMENT_TYPE', 'staging' );
 			break;
 		default:
 			putenv( 'WP_ENVIRONMENT_TYPE=development' );

--- a/wp-config-production.php
+++ b/wp-config-production.php
@@ -6,6 +6,11 @@
  * @package tw
  */
 
+// Ensure WP Environment Type constant is set.
+if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+	define( 'WP_ENVIRONMENT_TYPE', 'production' );
+}
+
 // Ensure debug mode is disabled.
 if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', false );

--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-config.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-config.php
@@ -4,3 +4,7 @@
  *
  * @package the_world_site_config
  */
+
+
+// Ensure Yoast optimization can be run in any environment.
+add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_true' );


### PR DESCRIPTION
- set WP_ENVIRONMENT_TYPE constant in staging and production env
- enable yoast optimization in all environments

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Go to http://the-world-wp.lndo.site/wp-admin/admin.php?page=wpseo_tools

> ...then...

- [x] Ensure "Start SEO data optimization" button is active.
