### PR TITLE
205: Add image credit URL field

### DIFF
--- a/wp-content/plugins/tw-image-credit/tw-image-credit.php
+++ b/wp-content/plugins/tw-image-credit/tw-image-credit.php
@@ -4,6 +4,8 @@
  * Plugin URI: https://www.dinkuminteractive.com/
  * Description: Add image credit and credit field.
  * Version: 1.0.0
+ *
+ * @package tw-image-credit
  */
 
 /**
@@ -24,14 +26,15 @@ function tw_add_media_credit_to_image_blocks( $block_content, array $block ) {
 	}
 
 	// Get attachment credit using the block id.
-	$attachment_credit = get_post_meta( $block['attrs']['id'], '_media_credit', true );
+	$attachment_credit     = get_post_meta( $block['attrs']['id'], '_media_credit', true );
+	$attachment_credit_url = get_post_meta( $block['attrs']['id'], '_media_credit_url', true );
 	if ( empty( $attachment_credit ) ) {
 		// Not a valid attachment, let's bail.
 		return $block_content;
 	}
 
 	// Filter if needed.
-	$block_content = apply_filters( 'tw_add_media_credit_to_image_blocks', $block_content, $attachment_credit );
+	$block_content = apply_filters( 'tw_add_media_credit_to_image_blocks', $block_content, $attachment_credit, $attachment_credit_url );
 
 	return $block_content;
 }
@@ -42,25 +45,28 @@ add_filter( 'render_block', 'tw_add_media_credit_to_image_blocks', 10, 2 );
  *
  * @param  string $block_content The block content.
  * @param  string $credit        The credit markup.
+ * @param  string $url           The credit url.
  *
  * @return string
  */
-function tw_inject_credit_into_caption( $block_content, $credit ) {
+function tw_inject_credit_into_caption( $block_content, $credit, $url ) {
 
 	// If we have a credit, inject it into the caption markup.
 	if ( $credit ) {
 
 		// Replacement parts.
-		$pattern     = '</figcaption>';
-		$open        = '<span class="media-credit">';
-		$credit = trim( $credit );
-		$close       = '</span>';
+		$pattern = '</figcaption>';
+		$open    = '<span class="media-credit">';
+		$credit  = trim( $credit );
+		$link    = "<a href=\"{$url}\" target=\"_blank\">{$credit}</a>";
+		$content = $url ? $link : $credit;
+		$close   = '</span>';
 
 		// Inject the credit into the caption markup.
-		$block_content = str_replace( $pattern, "{$open}{$credit}{$close}{$pattern}", $block_content );
+		$block_content = str_replace( $pattern, "{$open}{$content}{$close}{$pattern}", $block_content );
 	}
 
 	// Return the modified block content.
 	return $block_content;
 }
-add_filter( 'tw_add_media_credit_to_image_blocks', 'tw_inject_credit_into_caption', 10, 2 );
+add_filter( 'tw_add_media_credit_to_image_blocks', 'tw_inject_credit_into_caption', 10, 3 );

--- a/wp-content/themes/the-world/acf-json/group_62b485f48c100.json
+++ b/wp-content/themes/the-world/acf-json/group_62b485f48c100.json
@@ -1,69 +1,81 @@
 {
-  "key": "group_62b485f48c100",
-  "title": "File Meta - Migration",
-  "fields": [
-    {
-      "key": "field_62b4862efaff1",
-      "label": "Original URI",
-      "name": "original_uri",
-      "aria-label": "",
-      "type": "text",
-      "instructions": "",
-      "required": 0,
-      "conditional_logic": 0,
-      "wrapper": {
-        "width": "",
-        "class": "",
-        "id": ""
-      },
-      "default_value": "",
-      "placeholder": "",
-      "prepend": "",
-      "append": "",
-      "maxlength": ""
-    },
-    {
-      "key": "field_62b48652faff2",
-      "label": "Drupal ID",
-      "name": "fid",
-      "aria-label": "",
-      "type": "text",
-      "instructions": "",
-      "required": 0,
-      "conditional_logic": 0,
-      "wrapper": {
-        "width": "",
-        "class": "",
-        "id": ""
-      },
-      "default_value": "",
-      "placeholder": "",
-      "prepend": "",
-      "append": "",
-      "maxlength": ""
-    }
-  ],
-  "location": [
-    [
-      {
-        "param": "attachment",
-        "operator": "==",
-        "value": "all"
-      }
-    ]
-  ],
-  "menu_order": 10,
-  "position": "normal",
-  "style": "seamless",
-  "label_placement": "top",
-  "instruction_placement": "label",
-  "hide_on_screen": "",
-  "active": true,
-  "description": "",
-  "show_in_rest": 0,
-  "show_in_graphql": 0,
-  "graphql_field_name": "fileMeta",
-  "map_graphql_types_from_location_rules": 0,
-  "graphql_types": "",
-  "modified": 1709041316
+    "key": "group_62b485f48c100",
+    "title": "File Meta",
+    "fields": [
+        {
+            "key": "field_62b4862efaff1",
+            "label": "Original URI",
+            "name": "original_uri",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "Holds URL to remote file, usually in S3.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 0,
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_62b48652faff2",
+            "label": "Drupal ID",
+            "name": "fid",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "File ID from Drupal prior to migration.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 0,
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "attachment",
+                "operator": "==",
+                "value": "all"
+            },
+            {
+                "param": "current_user_role",
+                "operator": "==",
+                "value": "administrator"
+            },
+            {
+                "param": "user_role",
+                "operator": "==",
+                "value": "administrator"
+            }
+        ]
+    ],
+    "menu_order": 10,
+    "position": "normal",
+    "style": "seamless",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "show_in_graphql": 0,
+    "graphql_field_name": "fileMeta",
+    "map_graphql_types_from_location_rules": 0,
+    "graphql_types": "",
+    "modified": 1714496454
 }

--- a/wp-content/themes/the-world/acf-json/group_62d671b9ba699.json
+++ b/wp-content/themes/the-world/acf-json/group_62d671b9ba699.json
@@ -8,7 +8,7 @@
             "name": "image_title",
             "aria-label": "",
             "type": "text",
-            "instructions": "",
+            "instructions": "Provide a human readable title to be used in title attribute of image element. Will show up as a tooltip in most browsers and read by screen readers. Should be short and descriptive, but not as descriptive as the alt text.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -16,11 +16,12 @@
                 "class": "",
                 "id": ""
             },
+            "show_in_graphql": 1,
             "default_value": "",
-            "placeholder": "",
+            "maxlength": "",
+            "placeholder": "Example: \"Luke Skywalker Training With Yoda\"",
             "prepend": "",
-            "append": "",
-            "maxlength": ""
+            "append": ""
         },
         {
             "key": "field_622a6312b1b5d",
@@ -48,7 +49,7 @@
             "name": "_media_credit",
             "aria-label": "",
             "type": "text",
-            "instructions": "",
+            "instructions": "Give credit when credit is due. See image usage agreement for required credit text format.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -62,6 +63,24 @@
             "placeholder": "",
             "prepend": "",
             "append": ""
+        },
+        {
+            "key": "field_66311e6ccd8b9",
+            "label": "Image Credit URL",
+            "name": "_media_credit_url",
+            "aria-label": "",
+            "type": "url",
+            "instructions": "Provide link back to source as required by image usage agreement.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "placeholder": ""
         }
     ],
     "location": [
@@ -74,10 +93,10 @@
         ]
     ],
     "menu_order": 5,
-    "position": "normal",
+    "position": "side",
     "style": "default",
     "label_placement": "top",
-    "instruction_placement": "label",
+    "instruction_placement": "field",
     "hide_on_screen": "",
     "active": true,
     "description": "",
@@ -86,5 +105,5 @@
     "graphql_field_name": "imageFields",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1709042362
+    "modified": 1714499083
 }

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -65,14 +65,14 @@ if ( ! function_exists( 'tw_admin_styles' ) ) :
 	function tw_admin_styles() {
 		// Fixes layout heights of some accordion containers after WP 6.3 update.
 		echo '<style>
-			.components-panel__body { display: grid; }
 			.wpseo-meta-section, .wpseo-meta-section-react { min-height: unset; }
 		</style>';
 
 		// Hides device options from preview menu dropdown. They are basically useless and confusing.
 		echo '<style>
-			.edit-post-post-preview-dropdown .components-menu-group:first-child { display: none; }
-			.edit-post-post-preview-dropdown .components-menu-group + .components-menu-group { border-top: none; margin-top: -8px; }
+			.components-form-token-field__token-text { white-space: unset; }
+		    .components-dropdown-menu__menu:has(a[target^="wp-preview"]) .components-menu-group:not(:has(a[target^="wp-preview"])) { display: none; }
+			.components-dropdown-menu__menu:has(a[target^="wp-preview"]) .components-menu-group:has(a[target^="wp-preview"]) { border-top: none; margin-top: -8px; }
 		</style>';
 	}
 endif;


### PR DESCRIPTION
Closes #205 

- add image credit url field
- update image field groups to display in block editor dialogs
- add field descriptions to image fields

## To Review

- [x] Checkout Branch.
- [x] Run `npm run local` (or `npm run refresh` if you want a fresh database.)
- [x] Log into http://the-world-wp.lndo.site/wp-login.php
- [x] Ensure your Faust settings have `http://the-world-wp.lndo.site:3000` as the front-end URL.
- [x] Start review of PRX/theworld.org#462

> ...then...

- [x] Edit any story.
- [x] Click on the feature image to edit it (not the buttons on it).
- [x] Ensure image ACF fields show in edit dialog sidebar.
- [x] Add a image credit and image credit URL.
- [x] Click __Set feature image__ button to save changes.
- [x] Open preview of story.
- [x] Ensure lede image credit shows up as a link.
- [x] Edit any image in the content and add a image credit URL.
- [x] Save draft to update preview.
- [x] Ensure image credit shows up as link in content.
