### PR TITLE
#249 Add Audio Enclosures to RSS Feeds

### DIFF
--- a/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
+++ b/wp-content/mu-plugins/the-world-site-config/configs/global/global-plugins.php
@@ -40,6 +40,7 @@ define(
 		'tw-qa-block/tw-qa-block.php',
 		'tw-datawrapper-block/tw-datawrapper-block.php',
 		'tw-resource-development-tags/tw-resource-development-tags.php',
+		'tw-rss-helper/tw-rss-helper.php',
 		'tw-scroll-gallery/tw-scroll-gallery.php',
 		'tw-sitemap-mask/tw-sitemap-mask.php',
 		'tw-segments/tw-segments.php',

--- a/wp-content/plugins/tw-rss-helper/includes/rss.php
+++ b/wp-content/plugins/tw-rss-helper/includes/rss.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Add support to site RSS feed
+ *
+ * @since 1.0.0
+ */
+
+/**
+ * Add audio enclosure to RSS feed.
+ *
+ * This function will get post_rss_audio meta from a post.
+ * WARNING: This function will only work if ACF is active.
+ *
+ * @since 1.0.0
+ */
+function tw_rss_helper_audio_enclosure() {
+
+	// Check if ACF is active
+	if ( !function_exists('get_field') ) {
+		return false;
+	}
+
+	global $post;
+
+	// Get audio metadata.
+	$audio_id = get_post_meta( $post->ID, 'audio', true );
+
+	$audio_media = [];
+
+	$audio_url = wp_get_attachment_url( $audio_id );
+
+	// Bail early if no audio URL is found.
+	if ( $audio_url ) {
+
+		$audio_media['url'] = $audio_url;
+
+	} else {
+
+		return false;
+	}
+
+	$audio_filesize = tw_rss_helper_get_external_audio_url_filesize( $audio_url );
+
+	// If filesize is found, add it to the audio media array.
+	if ( $audio_filesize ) {
+		$audio_media['filesize'] = $audio_filesize;
+	}
+
+	// Build the default enclosure HTML.
+	$enclosure_html = sprintf(
+		'<enclosure url="%s" type="audio/mpeg" length="%s"/>',
+		$audio_media['url'],
+		$audio_media['filesize']
+	);
+
+	/**
+	 * Filter the audio enclosure HTML
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $enclosure_html The default enclosure HTML.
+	 * @param  int    $post_id        The post ID.
+	 * @param  array  $audio_media    The audio media array.
+	 *
+	 * @return string The audio enclosure HTML.
+	 */
+	$filtered_html = apply_filters(
+		'tw_rss_helper_audio_enclosure',
+		$enclosure_html,
+		$post->ID,
+		$audio_media
+	);
+
+	echo wp_kses(
+		$filtered_html,
+		array(
+			'enclosure' => array(
+				'url' => true,
+				'type' => true,
+				'length' => true,
+			),
+		)
+	);
+}
+add_action( 'rss2_item', 'tw_rss_helper_audio_enclosure' );
+
+/**
+ * Get external audio URL file size.
+ *
+ * @since 1.0.0
+ *
+ * @param  string $url The URL to get the file size of.
+ *
+ * @return int The file size of the URL.
+ */
+function tw_rss_helper_get_external_audio_url_filesize( $url ) {
+
+	$filesize = 0;
+
+	$headers = get_headers( $url, 1 );
+
+	if ( isset( $headers['Content-Length'] ) ) {
+
+		$content_length = $headers['Content-Length'];
+
+		if ( is_array( $content_length ) ) {
+
+			$filesize = max( array_map( 'intval', $content_length ) );
+
+		} else {
+
+			$filesize = intval( $content_length );
+		}
+	}
+
+	return $filesize;
+}

--- a/wp-content/plugins/tw-rss-helper/includes/rss.php
+++ b/wp-content/plugins/tw-rss-helper/includes/rss.php
@@ -15,8 +15,8 @@
  */
 function tw_rss_helper_audio_enclosure() {
 
-	// Check if ACF is active
-	if ( !function_exists('get_field') ) {
+	// Check if ACF is active.
+	if ( ! function_exists( 'get_field' ) ) {
 		return false;
 	}
 
@@ -25,31 +25,20 @@ function tw_rss_helper_audio_enclosure() {
 	// Get audio metadata.
 	$audio_id = get_post_meta( $post->ID, 'audio', true );
 
-	$audio_media = [];
-
 	$audio_url = wp_get_attachment_url( $audio_id );
 
 	// Bail early if no audio URL is found.
-	if ( $audio_url ) {
-
-		$audio_media['url'] = $audio_url;
-
-	} else {
-
+	if ( ! $audio_url ) {
 		return false;
 	}
 
-	$audio_filesize = tw_rss_helper_get_external_audio_url_filesize( $audio_url );
-
-	// If filesize is found, add it to the audio media array.
-	if ( $audio_filesize ) {
-		$audio_media['filesize'] = $audio_filesize;
-	}
+	$audio_media = tw_rss_helper_get_external_audio_data( $audio_url );
 
 	// Build the default enclosure HTML.
 	$enclosure_html = sprintf(
-		'<enclosure url="%s" type="audio/mpeg" length="%s"/>',
+		'<enclosure url="%1$s" type="%2$s" length="%3$s"/>',
 		$audio_media['url'],
+		$audio_media['mime_type'],
 		$audio_media['filesize']
 	);
 
@@ -75,8 +64,8 @@ function tw_rss_helper_audio_enclosure() {
 		$filtered_html,
 		array(
 			'enclosure' => array(
-				'url' => true,
-				'type' => true,
+				'url'    => true,
+				'type'   => true,
 				'length' => true,
 			),
 		)
@@ -91,27 +80,85 @@ add_action( 'rss2_item', 'tw_rss_helper_audio_enclosure' );
  *
  * @param  string $url The URL to get the file size of.
  *
- * @return int The file size of the URL.
+ * @return array The audio data.
  */
-function tw_rss_helper_get_external_audio_url_filesize( $url ) {
+function tw_rss_helper_get_external_audio_data( $url ) {
 
-	$filesize = 0;
+	// Default audio data.
+	$audio_data = array(
+		'url'       => $url,
+		'filesize'  => 0,
+		'mime_type' => 'audio/mpeg',
+	);
 
 	$headers = get_headers( $url, 1 );
 
+	// Try to get the filesize from the Content-Length header.
 	if ( isset( $headers['Content-Length'] ) ) {
 
 		$content_length = $headers['Content-Length'];
 
 		if ( is_array( $content_length ) ) {
 
-			$filesize = max( array_map( 'intval', $content_length ) );
+			$audio_data['filesize'] = max( array_map( 'intval', $content_length ) );
 
 		} else {
 
-			$filesize = intval( $content_length );
+			$audio_data['filesize'] = intval( $content_length );
 		}
 	}
 
-	return $filesize;
+	// Try to get file mime type from the Content-Type header.
+	if ( isset( $headers['Content-Type'] ) ) {
+
+		$content_type = $headers['Content-Type'];
+
+		if ( is_array( $content_type ) ) {
+
+			// Get the first value that contains "audio/".
+			$audio_data['mime_type'] = reset(
+				array_filter(
+					$content_type,
+					function ( $value ) {
+						return strpos( $value, 'audio/' ) === 0;
+					}
+				)
+			);
+
+		} elseif ( is_string( $content_type ) ) {
+
+			$audio_data['mime_type'] = strval( $content_type );
+		}
+	} else {
+		$audio_data['mime_type'] = tw_rss_helper_get_audio_mime_type( $url );
+	}
+
+	return $audio_data;
+}
+
+/**
+ * Get audio mime type from URL.
+ *
+ * @since 1.0.0
+ *
+ * @param  string $url The URL to get the mime type of.
+ *
+ * @return string The audio mime type.
+ */
+function tw_rss_helper_get_audio_mime_type( $url ) {
+	// Extract the file extension.
+	$extension = pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+
+	if ( ! empty( $extension ) ) {
+		// Check if it's a recognized audio extension in WordPress.
+		$file_info = wp_check_filetype( $extension );
+
+		// Validate that it's an audio type.
+		if ( ! empty( $file_info['ext'] ) && strpos( $file_info['type'], 'audio/' ) === 0 ) {
+			return $file_info['type'];
+		}
+	}
+
+	// Return audio/mpeg as the default type.
+	return 'audio/mpeg';
 }

--- a/wp-content/plugins/tw-rss-helper/tw-rss-helper.php
+++ b/wp-content/plugins/tw-rss-helper/tw-rss-helper.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: TW RSS Helper
+ * Plugin URI: https://dinkuminteractive.com
+ * Description: Adds RSS audio support to posts using ACF.
+ * Requires at least: 6.1
+ * Requires PHP:      7.0
+ * Version: 1.0.0
+ * Author: Dinkum Interactive
+ * Author URI: https://dinkuminteractive.com
+ * License: GPL-2.0+
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Current plugin version.
+ */
+define( 'TW_RSS_HELPER_VERSION', '1.0.0' );
+
+/**
+ * Plugin path.
+ */
+define( 'TW_RSS_HELPER_PATH', plugin_dir_path( __FILE__ ) );
+
+/**
+ * Include the RSS functionality.
+ */
+require_once TW_RSS_HELPER_PATH . 'includes/rss.php';


### PR DESCRIPTION
Closes #249 

- Add enclosure tag based on a post audio meta.

## To Review

- [x] Make sure the plugin is running. Enqueue in `mu-plugins/the-world-site-config/configs/global/global-plugins.php`
- [x] Open admin post edit page of the latest post and make sure audio field has media attached to it.
- [ ] Check the wp feed page: {site-url}/feed. Enclosure tag should be added.
