### PR TITLE
#248 RSS Feeds pointing to the Post Author, not the Contributor

### DIFF
--- a/wp-content/plugins/tw-contributors/tw-contributors.php
+++ b/wp-content/plugins/tw-contributors/tw-contributors.php
@@ -56,3 +56,53 @@ function tw_contributors_taxonomy() {
 	register_taxonomy( 'contributor', array( 'post', 'attachment', 'segment' ), $args );
 }
 add_action( 'init', 'tw_contributors_taxonomy', 0 );
+
+/**
+ * Change RSS feed author name.
+ *
+ * @param string $author
+ *
+ * @return string
+ */
+function tw_contributors_rss_author( $author ) {
+
+	if ( is_feed() ) {
+
+		global $post;
+
+		$author = tw_contributors_get_post_contributors_string( $post->ID );
+	}
+
+	return $author;
+}
+add_filter( 'the_author', 'tw_contributors_rss_author' );
+
+/**
+ * Get author byline.
+ *
+ * @param int $post_id The post ID.
+ *
+ * @return string The author byline.
+ */
+function tw_contributors_get_post_contributors_string( $post_id ) {
+
+	$contributors = '';
+
+	// Get contributor taxonomy terms.
+	$contributor_terms = get_the_terms( $post_id, 'contributor' );
+
+	// Bail early if no contributor terms are found.
+	if (
+		! $contributor_terms
+		||
+		! is_array( $contributor_terms )
+	) {
+		return $contributors;
+	}
+
+	$contributor_titles = wp_list_pluck( $contributor_terms, 'name' );
+
+	$author_byline = implode( ', ', $contributor_titles );
+
+	return $author_byline;
+}

--- a/wp-content/plugins/tw-contributors/tw-contributors.php
+++ b/wp-content/plugins/tw-contributors/tw-contributors.php
@@ -66,9 +66,23 @@ add_action( 'init', 'tw_contributors_taxonomy', 0 );
  */
 function tw_contributors_rss_author( $author ) {
 
+	// Check if we're in a feed.
 	if ( is_feed() ) {
 
 		global $post;
+
+		// Bail early if not a post.
+		if ( ! $post instanceof WP_Post ) {
+			return $author;
+		}
+
+		// List of affected post types.
+		$affected_post_types = array( 'post', 'episode', 'segment' );
+
+		// Bail early if not an affected post type.
+		if ( ! in_array( $post->post_type, $affected_post_types, true ) ) {
+			return $author;
+		}
 
 		$author = tw_contributors_get_post_contributors_string( $post->ID );
 	}


### PR DESCRIPTION
Closes #248 

- Modify the RSS author to use post contributor.

## To Review

- [x] Make sure the plugin is running. Enqueue in `mu-plugins/the-world-site-config/configs/global/global-plugins.php`
- [x] Open admin post edit page of the latest post and make sure contributors are selected.
- [x] Check the wp feed page: {site-url}/feed. The creator tag should use post contributor names.