### PR TITLE
#256: Add RD Tags to segments and episodes 

### DIFF
--- a/wp-content/plugins/tw-resource-development-tags/tw-resource-development-tags.php
+++ b/wp-content/plugins/tw-resource-development-tags/tw-resource-development-tags.php
@@ -67,6 +67,6 @@ function tw_resource_development_tags_taxonomy() {
 		'graphql_single_name'   => 'resourceDevelopmentTag',
 		'graphql_plural_name'   => 'resourceDevelopmentTags',
 	);
-	register_taxonomy( 'resource_development', array( 'post' ), $args );
+	register_taxonomy( 'resource_development', array( 'post', 'episode', 'segment' ), $args );
 }
 add_action( 'init', 'tw_resource_development_tags_taxonomy', 0 );


### PR DESCRIPTION
#256 part 1
- Adds RD Tags to Segments and Episodes

## To Review

- [ ] Checkout Branch.
- [ ] Start Lando, if it is not already running: `lando start`.
- [ ] Go to http://the-world-wp.lndo.site/wp-admin and log in.

> ...then...

- [ ] Confirm RD tags are available to segments
- [ ] Confirm RD Tags are available to episodes
